### PR TITLE
fix: 修复 Streamable HTTP 未应用 MCP 读取超时的问题

### DIFF
--- a/src/mcp_module/connection.py
+++ b/src/mcp_module/connection.py
@@ -288,7 +288,11 @@ class MCPConnection:
             merged_headers.update(headers)
         return httpx.AsyncClient(
             headers=merged_headers,
-            timeout=timeout or httpx.Timeout(self.config.http_timeout_seconds),
+            timeout=timeout
+            or httpx.Timeout(
+                self.config.http_timeout_seconds,
+                read=self.config.read_timeout_seconds,
+            ),
         )
 
     async def _create_client_session(self, read_stream: Any, write_stream: Any) -> Any:


### PR DESCRIPTION


<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
为 HTTPX 响应读取应用 read_timeout_seconds，避免长耗时 MCP 工具在服务端正常完成后因底层 HTTP 读取提前超时而丢失响应。
# 其他信息
- **关联 Issue**：#1983
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化未显式设置超时时的网络请求处理，分别配置连接和读取超时。
  * 保留显式传入超时设置的原有行为，提升请求稳定性与可控性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->