### PR TITLE
fix(maisaka): 主动回合前从消息库回填用户消息，修复主动发言无引用目标

### DIFF
--- a/pytests/maisaka/test_proactive_context_restore.py
+++ b/pytests/maisaka/test_proactive_context_restore.py
@@ -1,0 +1,226 @@
+"""主动回合用户消息回填的编排逻辑测试。
+
+`restore_proactive_user_context` 复用启动恢复的取数与转换链路，这里只验证
+主动场景特有的编排行为：何时回填、去重、插入位置与失败兜底。
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from src.common.data_models.message_component_data_model import MessageSequence, TextComponent
+from src.maisaka.context.messages import SessionBackedMessage
+from src.maisaka.runtime import MaisakaHeartFlowChatting
+
+
+def _session_backed_message(message_id: str, source_kind: str = "user") -> SessionBackedMessage:
+    return SessionBackedMessage(
+        raw_message=MessageSequence([TextComponent("消息内容")]),
+        visible_text=f"19:51:07[msg_id:{message_id}][某人]消息内容",
+        timestamp=datetime(2026, 8, 23, 19, 51, 7),
+        message_id=message_id,
+        source_kind=source_kind,
+    )
+
+
+def _repository_message(message_id: str, *, is_notify: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(message_id=message_id, is_notify=is_notify, is_command=False)
+
+
+def _build_runtime(
+    chat_history: list[Any],
+    repository_messages: list[Any] | None = None,
+    *,
+    repository_error: Exception | None = None,
+    session_scoped_messages: list[Any] | None = None,
+    is_group_chat: bool = True,
+    group_id: str = "10086",
+    user_id: str = "",
+) -> tuple[SimpleNamespace, dict[str, Any]]:
+    calls: dict[str, Any] = {"find_messages": []}
+    built_sources: list[str] = []
+
+    async def fake_build_history_message(message: Any, *, source_kind: str = "user") -> SessionBackedMessage:
+        built_sources.append(source_kind)
+        return _session_backed_message(message.message_id, source_kind=source_kind)
+
+    def fake_find_messages(**kwargs: Any) -> list[Any]:
+        calls["find_messages"].append(kwargs)
+        if repository_error is not None:
+            raise repository_error
+        # 默认 session_id 查询直接返回 repository_messages；显式传入
+        # session_scoped_messages 时模拟会话流分裂（session 查空，回退查询才有历史）。
+        if kwargs.get("session_id") is not None:
+            if session_scoped_messages is not None:
+                return session_scoped_messages
+            return repository_messages or []
+        return repository_messages or []
+
+    runtime = SimpleNamespace(
+        _chat_history=chat_history,
+        session_id="session-1",
+        log_prefix="[测试会话]",
+        _get_context_restore_limit=lambda: 18,
+        _reasoning_engine=SimpleNamespace(_build_history_message=fake_build_history_message),
+        chat_stream=SimpleNamespace(
+            platform="qq",
+            is_group_session=is_group_chat,
+            group_id=group_id,
+            user_id=user_id,
+        ),
+    )
+    runtime.__dict__["_fake_find_messages"] = fake_find_messages
+    return runtime, {"calls": calls, "built_sources": built_sources, "fake_find_messages": fake_find_messages}
+
+
+def _patch_repository(monkeypatch: pytest.MonkeyPatch, runtime: SimpleNamespace, harness: dict[str, Any]) -> None:
+    monkeypatch.setattr("src.maisaka.runtime.find_messages", harness["fake_find_messages"])
+    monkeypatch.setattr(
+        "src.maisaka.runtime.select_messages_after_latest_clear_marker",
+        lambda messages: list(messages),
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_without_query_when_history_already_has_user_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, harness = _build_runtime([_session_backed_message("m-existing")])
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 0
+    assert harness["calls"]["find_messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_restores_user_messages_before_existing_session_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bot_message = _session_backed_message("m-bot", source_kind="guided_reply")
+    runtime, harness = _build_runtime(
+        [bot_message],
+        repository_messages=[_repository_message("m-old-1"), _repository_message("m-old-2")],
+    )
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 2
+    assert [message.message_id for message in runtime._chat_history] == ["m-old-1", "m-old-2", "m-bot"]
+    assert harness["built_sources"] == ["user", "user"]
+    assert harness["calls"]["find_messages"][0]["session_id"] == "session-1"
+    assert harness["calls"]["find_messages"][0]["filter_bot"] is True
+
+
+@pytest.mark.asyncio
+async def test_skips_notify_and_already_present_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    existing_bot_message = _session_backed_message("m-dup", source_kind="guided_reply")
+    runtime, harness = _build_runtime(
+        [existing_bot_message],
+        repository_messages=[
+            _repository_message("m-dup"),
+            _repository_message("m-notify", is_notify=True),
+            _repository_message("m-new"),
+        ],
+    )
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 1
+    assert [message.message_id for message in runtime._chat_history] == ["m-new", "m-dup"]
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_repository_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, harness = _build_runtime([], repository_error=RuntimeError("数据库暂不可用"))
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 0
+    assert runtime._chat_history == []
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_repository_has_no_restorable_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, harness = _build_runtime([], repository_messages=[])
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 0
+    assert runtime._chat_history == []
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_group_query_when_session_history_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bot_message = _session_backed_message("m-bot", source_kind="guided_reply")
+    runtime, harness = _build_runtime(
+        [bot_message],
+        repository_messages=[_repository_message("m-old")],
+        session_scoped_messages=[],
+        is_group_chat=True,
+        group_id="10086",
+    )
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 1
+    assert [message.message_id for message in runtime._chat_history] == ["m-old", "m-bot"]
+    queries = harness["calls"]["find_messages"]
+    assert len(queries) == 2
+    assert queries[0].get("session_id") == "session-1"
+    assert queries[1].get("group_id") == "10086"
+    assert queries[1].get("platform") == "qq"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_user_query_for_private_chat_when_session_history_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime, harness = _build_runtime(
+        [],
+        repository_messages=[_repository_message("m-private")],
+        session_scoped_messages=[],
+        is_group_chat=False,
+        user_id="2933634892",
+    )
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 1
+    assert [message.message_id for message in runtime._chat_history] == ["m-private"]
+    queries = harness["calls"]["find_messages"]
+    assert len(queries) == 2
+    assert queries[1].get("user_id") == "2933634892"
+    assert "group_id" not in queries[1]
+
+
+@pytest.mark.asyncio
+async def test_guard_ignores_user_message_without_usable_message_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 历史 user 消息缺 message_id 时不构成可引用目标，守卫不得短路，仍需回填
+    idless_user_message = _session_backed_message("", source_kind="user")
+    idless_user_message.message_id = None
+    runtime, harness = _build_runtime(
+        [idless_user_message],
+        repository_messages=[_repository_message("m-restored")],
+    )
+    _patch_repository(monkeypatch, runtime, harness)
+
+    restored = await MaisakaHeartFlowChatting.restore_proactive_user_context(runtime)  # type: ignore[arg-type]
+
+    assert restored == 1
+    assert [message.message_id for message in runtime._chat_history] == ["m-restored", None]

--- a/src/maisaka/reasoning_engine.py
+++ b/src/maisaka/reasoning_engine.py
@@ -915,6 +915,7 @@ class MaisakaReasoningEngine:
             if trigger_message is None:
                 logger.warning(f"{self._runtime.log_prefix} 主动触发缺少对应的触发消息，跳过本轮")
                 return TurnStartContext([], None, timeout_triggered, proactive_triggered, silent_reply_frequency)
+            await self._runtime.restore_proactive_user_context()
             if self._runtime._has_pending_wait_tool_call():
                 wait_message = self._build_wait_completed_message(has_new_messages=False)
                 continuation_logical_turn_id = wait_message.logical_turn_id

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -370,6 +370,79 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
 
         return max(1, ceil(self._max_context_size * CONTEXT_RESTORE_FILL_RATIO))
 
+    async def restore_proactive_user_context(self) -> int:
+        """主动回合前确保上下文含有可回复的真实用户消息。
+
+        主动任务触发于长期静默的聊天流，运行时历史中可能没有任何带
+        msg_id 的用户消息，Planner 唯一的文本出口 reply 会因缺少引用
+        目标而无法发言。此处复用启动恢复的取数与转换链路，从消息库
+        回填最近的用户消息作为可引用目标。返回本次回填的消息条数。
+        """
+
+        if any(
+            isinstance(message, SessionBackedMessage) and message.source_kind == "user" and message.message_id
+            for message in self._chat_history
+        ):
+            return 0
+
+        try:
+            recent_messages = await asyncio.to_thread(
+                find_messages,
+                session_id=self.session_id,
+                limit=self._get_context_restore_limit(),
+                limit_mode="latest",
+                filter_bot=True,
+            )
+            # 会话流发生分裂迁移时，历史消息仍挂在旧 session_id 下，
+            # 此时按平台目标（群号或用户号）回退查询，保证仍能取到历史。
+            if not recent_messages:
+                if self.chat_stream.is_group_session:
+                    recent_messages = await asyncio.to_thread(
+                        find_messages,
+                        platform=self.chat_stream.platform,
+                        group_id=self.chat_stream.group_id,
+                        limit=self._get_context_restore_limit(),
+                        limit_mode="latest",
+                        filter_bot=True,
+                    )
+                else:
+                    recent_messages = await asyncio.to_thread(
+                        find_messages,
+                        platform=self.chat_stream.platform,
+                        user_id=self.chat_stream.user_id,
+                        limit=self._get_context_restore_limit(),
+                        limit_mode="latest",
+                        filter_bot=True,
+                    )
+        except Exception as exc:
+            logger.warning(f"{self.log_prefix} 主动回合回填用户消息失败: {exc}", exc_info=True)
+            return 0
+
+        recent_messages = select_messages_after_latest_clear_marker(recent_messages)
+        existing_message_ids = {
+            message.message_id
+            for message in self._chat_history
+            if isinstance(message, SessionBackedMessage) and message.message_id
+        }
+        restored_history: list[LLMContextMessage] = []
+        for message in recent_messages:
+            if message.is_notify or message.message_id in existing_message_ids:
+                continue
+            history_message = await self._reasoning_engine._build_history_message(message, source_kind="user")
+            if history_message is not None:
+                restored_history.append(history_message)
+
+        if not restored_history:
+            return 0
+
+        insert_index = next(
+            (index for index, message in enumerate(self._chat_history) if isinstance(message, SessionBackedMessage)),
+            len(self._chat_history),
+        )
+        self._chat_history[insert_index:insert_index] = restored_history
+        logger.info(f"{self.log_prefix} 主动回合已回填用户消息 {len(restored_history)} 条，作为可回复引用目标")
+        return len(restored_history)
+
     @staticmethod
     def _build_context_restore_reference_message(
         restored_history: Sequence[LLMContextMessage],


### PR DESCRIPTION
Close #2006

## 问题与根因

见关联 issue。核心：主动回合上下文中没有任何带 msg_id 的用户消息时，`reply` 唯一的文本出口不可用，Planner 只能放弃。

## 修复方式

新增 `MaisakaHeartFlowChatting.restore_proactive_user_context()`，在 `reasoning_engine` 消费主动触发消息后调用：

- **复用启动恢复既有链路**：`find_messages` / `select_messages_after_latest_clear_marker` / `_build_history_message` / `_get_context_restore_limit`，不引入新机制；
- **守卫零开销**：历史中已有 `source_kind="user"` 的消息时直接返回；
- **去重与时序**：按 message_id 去重（含 notify 跳过），回填消息插入到第一条 `SessionBackedMessage` 之前，保证时间顺序；
- **会话流分裂回退**：session_id 查询为空时，群聊按 `platform + group_id`、私聊按 `platform + user_id` 回退查询——生产中实测存在同一群新旧两条 session、历史全挂旧 session 的情况，此场景下按 session_id 查询恒为空。

## 生产验证（1.2.1，会话流分裂群 + 重启后历史真空）

修复前（同一环境，主动回合）：

```
（Planner）无历史聊天上下文可参考……当前无有效发送载体，结束本轮思考
```

修复后日志时间线：

```
13:39:47  [测试插件] 已触发主动任务: stream_id=68e1ce46...
13:39:48  [群名脱敏] 主动回合已回填用户消息 17 条，作为可回复引用目标
13:40:27  [SendService] 发送text消息到 68e1ce46...
13:40:57  [SendService] 发送text消息到 68e1ce46...
13:41:37  [SendService] 发送emoji消息到 68e1ce46...
```

Planner 在上下文中获得 17 条带 msg_id 的真实用户消息后，成功引用并发送文本回复，出站成功。

## 与 #1998 的区别

#1998 修复工具调用轮次的 user 前置消息保序；本 PR 修复主动回合缺少可引用用户消息。同属 maisaka 消息构造但互不重叠。

## 数据库声明

仅只读查询（find_messages），无数据库结构或写入变更。

## 测试

新增 `pytests/maisaka/test_proactive_context_restore.py` 共 7 个用例：

| 用例 | 覆盖 |
|---|---|
| 守卫短路 | 已有用户消息时不查库直接返回 |
| 回填与插入位置 | 回填消息插到既有会话消息之前 |
| 去重与 notify 跳过 | 重复 message_id 与 notify 不回填 |
| 查询异常兜底 | find_messages 抛错返回 0 不影响回合 |
| 空库 | 无可回填消息时优雅跳过 |
| 群聊分裂回退 | session 查空后按 group_id 回退查询 |
| 私聊回退 | session 查空后按 user_id 回退查询 |

```
$ pytest pytests/maisaka/test_proactive_context_restore.py
7 passed
$ pytest pytests/maisaka/
53 passed
$ ruff check src/maisaka/ pytests/maisaka/test_proactive_context_restore.py
All checks passed!
$ ruff format --check ...
3 files already formatted
```

## 破坏性更新

无。

**勾选**：非 main 分支（基于 dev）✔ ｜ 已读贡献指南 ✔ ｜ BUG 修复 ✔ ｜ 经过测试 ✔


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 主动回合触发前可自动恢复近期用户消息，补充必要的对话上下文。
  * 支持按群聊或私聊条件查找历史消息，并保持消息顺序、去重及过滤通知内容。
  * 在历史消息缺失、查询无结果或处理异常时安全降级，不影响主动回合流程。

* **测试**
  * 新增对消息恢复、异常处理、去重及多种查询回退场景的覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->