### PR TITLE
fix: 优化心流租约与生命周期，修复全仓内存与资源泄露并补齐测试用例

### DIFF
--- a/dashboard/src/routes/resource/__tests__/knowledge-base.test.tsx
+++ b/dashboard/src/routes/resource/__tests__/knowledge-base.test.tsx
@@ -245,6 +245,16 @@ async function openMemoryStatusDialog(user: ReturnType<typeof userEvent.setup>) 
   await screen.findByRole('dialog', { name: '记忆状态' })
 }
 
+async function openTuningTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('tab', { name: '记忆检修' }))
+  await user.click(await screen.findByRole('tab', { name: '检索调优' }))
+}
+
+async function openCorrectionTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('tab', { name: '记忆检修' }))
+  await user.click(await screen.findByRole('tab', { name: '内容修正' }))
+}
+
 describe('KnowledgeBasePage import workflow', () => {
   beforeEach(async () => {
     await i18n.changeLanguage('zh')
@@ -1533,7 +1543,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
 
     await user.click(screen.getByRole('button', { name: '开始调优' }))
@@ -1560,7 +1570,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
 
     expect(screen.getByText('评估并改善记忆搜索效果')).toBeVisible()
@@ -1600,7 +1610,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
     await user.click(screen.getByRole('button', { name: '开始调优' }))
 
@@ -1622,7 +1632,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
     await user.click(screen.getByRole('button', { name: '应用推荐结果' }))
 
@@ -1640,7 +1650,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('当前调优结果')
 
     expect(screen.getByText('验证通过，建议应用。')).toBeInTheDocument()
@@ -1669,7 +1679,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('当前调优结果')
 
     expect(screen.getByText('任务状态')).toBeInTheDocument()
@@ -1698,7 +1708,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('当前调优结果')
 
     expect(screen.getAllByText('失败').length).toBeGreaterThan(0)
@@ -1755,7 +1765,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('当前调优结果')
 
     expect(screen.getByText('验证未通过，不建议应用。')).toBeInTheDocument()
@@ -1770,7 +1780,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
 
     await user.click(screen.getByRole('button', { name: '调优参数' }))
@@ -1794,7 +1804,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
 
     expect(screen.getByRole('button', { name: '应用推荐结果' })).toBeDisabled()
@@ -1816,7 +1826,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '调优' }))
+    await openTuningTab(user)
     await screen.findByText('记忆搜索调优')
 
     const applyButton = screen.getByRole('button', { name: '应用推荐结果' })
@@ -1972,7 +1982,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '记忆修正' }))
+    await openCorrectionTab(user)
     await screen.findByLabelText('修正内容')
     await screen.findByText('correction-plan-1')
     await waitFor(() => expect(memoryApi.getMemoryCorrectionPlan).toHaveBeenCalledWith('correction-plan-1'))
@@ -1997,7 +2007,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '记忆修正' }))
+    await openCorrectionTab(user)
     await screen.findByLabelText('修正内容')
 
     await user.type(screen.getByLabelText('修正内容'), '把测试用户的常住城市改为杭州')
@@ -2021,7 +2031,7 @@ describe('KnowledgeBasePage import workflow', () => {
     renderPage()
 
     await waitForConsoleReady()
-    await user.click(screen.getByRole('tab', { name: '记忆修正' }))
+    await openCorrectionTab(user)
     await screen.findByText('correction-plan-1')
     await waitFor(() => expect(memoryApi.getMemoryCorrectionPlan).toHaveBeenCalledWith('correction-plan-1'))
 

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,41 +19,41 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-28 17:30 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-29 13:37 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,837</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,841</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">601</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">603</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">49</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">52</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">12</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">14</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">192</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">191</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -67,7 +67,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">38</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">36</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">90c8263</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">1 天前</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">0d5d998</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">19 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,55 +19,55 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-23 09:26 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-27 15:16 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,783</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,823</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">600</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">601</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">44</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">48</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">10</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">11</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">212</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">205</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">7</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">11</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">42</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">38</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">89da36c</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">461d1b5</text>
     <text x="156" y="12" fill="#57606a" font-size="13">1 天前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,20 +19,20 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-02 10:51 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-03 10:54 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,865</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,870</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">615</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">616</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
@@ -46,28 +46,28 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">15</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">14</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">229</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">221</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">10</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">11</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">31</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">30</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">21cd74d</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">15 小时前</text>
-    <text x="246" y="12" fill="#24292f" font-size="13">Merge pull request #2030 from Mai-with-u/dev</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">ed8493c</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
+    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,27 +19,27 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-29 13:37 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-30 11:36 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,841</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,850</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">603</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">604</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">52</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">53</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
@@ -53,21 +53,21 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">191</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">179</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">9</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">8</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">36</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">32</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">0d5d998</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">19 小时前</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">c007355</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">21 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,27 +19,27 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-30 11:36 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-31 11:36 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,850</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,856</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">604</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">609</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">53</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">54</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
@@ -53,7 +53,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">179</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">177</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">c007355</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">21 小时前</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">27ddf1e</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,13 +19,13 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-03 10:54 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-04 10:54 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,870</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,876</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
@@ -39,7 +39,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">51</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">52</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
@@ -53,21 +53,21 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">221</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">193</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">11</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">9</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">30</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">28</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">ed8493c</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">ad3a032</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,20 +19,20 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-31 11:36 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-01 11:33 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,856</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,862</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">609</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">614</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
@@ -60,14 +60,14 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">8</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">9</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">32</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">29</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">27ddf1e</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
-    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">45e3fac</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">17 小时前</text>
+    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新 Star 历史图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,13 +19,13 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-27 15:16 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-08-28 17:30 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,823</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,837</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
@@ -39,28 +39,28 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">48</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">49</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">11</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">12</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">205</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">192</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">11</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">9</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">461d1b5</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">90c8263</text>
     <text x="156" y="12" fill="#57606a" font-size="13">1 天前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,69 +19,69 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-01 11:33 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-02 10:51 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,862</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,865</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">614</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">615</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">54</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">51</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">14</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">15</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">177</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">229</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f08c00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Merged PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">9</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">10</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(472 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">29</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">31</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#37b24d"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Contributors</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">117</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">118</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">贡献者</text>
   </g>
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">45e3fac</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">17 小时前</text>
-    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新 Star 历史图</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">21cd74d</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">15 小时前</text>
+    <text x="246" y="12" fill="#24292f" font-size="13">Merge pull request #2030 from Mai-with-u/dev</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,27 +19,27 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-04 10:54 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-05 10:56 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,876</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,882</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">616</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">615</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">52</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">54</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
@@ -53,7 +53,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">193</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">190</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">ad3a032</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">f976ae7</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,13 +19,13 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-08 11:02 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-09 11:03 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,897</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,904</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
@@ -53,7 +53,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">172</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">170</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -67,7 +67,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">22</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">15</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">3fd8499</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">18 小时前</text>
-    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新 Star 历史图</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">4213d8c</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
+    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,20 +19,20 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-09 11:03 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-10 11:04 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,904</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,912</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">615</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">620</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
@@ -46,14 +46,14 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">16</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">17</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">170</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">163</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -67,7 +67,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">15</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">14</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">4213d8c</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">6a2a624</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,13 +19,13 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-05 10:56 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-06 10:55 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,882</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,886</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
@@ -39,21 +39,21 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">54</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">55</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">14</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">15</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">190</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">183</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -67,7 +67,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">28</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">27</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">f976ae7</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">2783653</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,13 +19,13 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-11 10:59 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-12 11:06 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,919</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,926</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">6ab2bac</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">1ec3a5a</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,27 +19,27 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-07 10:52 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-08 11:02 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,890</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,897</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">616</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">615</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">56</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">55</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
@@ -53,7 +53,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">178</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">172</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -67,7 +67,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">21</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">22</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,8 +80,8 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">c13d9fb</text>
-    <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
-    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">3fd8499</text>
+    <text x="156" y="12" fill="#57606a" font-size="13">18 小时前</text>
+    <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新 Star 历史图</text>
   </g>
 </svg>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,41 +19,41 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-06 10:55 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-07 10:52 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,886</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,890</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">615</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">616</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#e8590c"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">55</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">56</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待处理问题</text>
   </g>
   <g transform="translate(694 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#66a80f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Open PRs</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">15</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">16</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">待合并请求</text>
   </g>
   <g transform="translate(28 224)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">183</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">178</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -67,7 +67,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#d9480f"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Closed Issues</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">27</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">21</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(694 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">2783653</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">c13d9fb</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,20 +19,20 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-10 11:04 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-11 10:59 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,912</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,919</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">620</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">621</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
@@ -53,7 +53,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">163</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">158</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">6a2a624</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">6ab2bac</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/depends-data/repository-metrics.svg
+++ b/depends-data/repository-metrics.svg
@@ -19,20 +19,20 @@
   <text x="38" y="80" fill="#fff4d6" font-size="13">MaiSaka, an LLM-based intelligent agent, is a digital lifeform devoted to understanding you and interacti</text>
   <text x="760" y="47" fill="#ffffff" font-size="13" text-anchor="end">默认分支</text>
   <text x="882" y="47" fill="#ffffff" font-size="18" font-weight="700" text-anchor="end">main</text>
-  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-12 11:06 UTC+8</text>
+  <text x="882" y="75" fill="#fff4d6" font-size="12" text-anchor="end">更新于 2026-09-13 11:08 UTC+8</text>
 
   <g transform="translate(28 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#f59f00"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Stars</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,926</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">5,937</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">累计收藏</text>
   </g>
   <g transform="translate(250 126)">
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#2f9e44"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Forks</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">621</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">623</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">派生仓库</text>
   </g>
   <g transform="translate(472 126)">
@@ -53,7 +53,7 @@
     <rect width="206" height="82" rx="10" fill="#ffffff" stroke="#d8dee4"/>
     <rect x="0" y="0" width="5" height="82" rx="2.5" fill="#099268"/>
     <text x="20" y="27" fill="#57606a" font-size="13">Commits</text>
-    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">158</text>
+    <text x="20" y="55" fill="#24292f" font-size="25" font-weight="700">150</text>
     <text x="110" y="55" fill="#6e7781" font-size="12">最近 30 天</text>
   </g>
   <g transform="translate(250 224)">
@@ -80,7 +80,7 @@
   <g transform="translate(28 318)">
     <circle cx="8" cy="8" r="5" fill="#1f883d"/>
     <text x="22" y="12" fill="#57606a" font-size="13">最后提交</text>
-    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">1ec3a5a</text>
+    <text x="94" y="12" fill="#24292f" font-size="13" font-weight="700">d5e4b37</text>
     <text x="156" y="12" fill="#57606a" font-size="13">23 小时前</text>
     <text x="246" y="12" fill="#24292f" font-size="13">docs: 更新仓库状态图</text>
   </g>

--- a/pytests/A_memorix_test/test_lpmm_convert.py
+++ b/pytests/A_memorix_test/test_lpmm_convert.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Generator
 
 import json
+import os
 import subprocess
 import sys
 
@@ -41,6 +42,8 @@ def _write_parquet(path: Path, rows: list[dict[str, object]]) -> None:
 
 def _run_convert(input_dir: Path, output_dir: Path, *, dimension: int = 2) -> subprocess.CompletedProcess[str]:
     data_dir = input_dir.parents[3]
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
     return subprocess.run(
         [
             sys.executable,
@@ -61,6 +64,7 @@ def _run_convert(input_dir: Path, output_dir: Path, *, dimension: int = 2) -> su
         text=True,
         encoding="utf-8",
         errors="replace",
+        env=env,
     )
 
 
@@ -76,6 +80,8 @@ def test_lpmm_converter_rejects_paths_outside_import_root(tmp_path: Path) -> Non
     data_dir = tmp_path / "a-memorix"
     outside_input = tmp_path / "outside"
     outside_input.mkdir()
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
         [
             sys.executable,
@@ -93,6 +99,7 @@ def test_lpmm_converter_rejects_paths_outside_import_root(tmp_path: Path) -> Non
         text=True,
         encoding="utf-8",
         errors="replace",
+        env=env,
     )
 
     assert result.returncode != 0

--- a/pytests/A_memorix_test/test_real_storage_delete_outbox.py
+++ b/pytests/A_memorix_test/test_real_storage_delete_outbox.py
@@ -117,15 +117,23 @@ def _runtime_config(data_dir: Path) -> Dict[str, Any]:
 
 
 async def _open_runtime(data_dir: Path) -> SDKMemoryKernel:
-    kernel = SDKMemoryKernel(
-        plugin_root=Path.cwd(),
-        config=_runtime_config(data_dir),
-    )
-    await kernel.initialize()
-    await kernel._stop_background_tasks()
-
     embedding = OfflineDeterministicEmbedding(EMBEDDING_DIMENSION)
     await embedding.initialize()
+
+    import src.A_memorix.core.runtime.sdk_memory_kernel as smk
+    old_create = smk.create_embedding_api_adapter
+    smk.create_embedding_api_adapter = lambda *args, **kwargs: embedding
+    try:
+        kernel = SDKMemoryKernel(
+            plugin_root=Path.cwd(),
+            config=_runtime_config(data_dir),
+        )
+        await kernel.initialize()
+    finally:
+        smk.create_embedding_api_adapter = old_create
+
+    await kernel._stop_background_tasks()
+
     kernel.embedding_manager = embedding
     kernel.embedding_dimension = EMBEDDING_DIMENSION
     if kernel._vector_health.get("error_code") == "embedding_fingerprint_unavailable":

--- a/pytests/config_test/test_startup_bindings.py
+++ b/pytests/config_test/test_startup_bindings.py
@@ -15,8 +15,8 @@ from src.config.startup_bindings import (
 def test_startup_bindings_use_defaults_when_config_file_missing(tmp_path: Path):
     missing_path = tmp_path / "missing_bot_config.toml"
 
-    assert get_startup_main_bind_address(missing_path) == BindAddress(host="127.0.0.1", port=8080)
-    assert get_startup_webui_bind_address(missing_path) == BindAddress(host="127.0.0.1", port=8001)
+    assert get_startup_main_bind_address(missing_path) == BindAddress(hosts=["127.0.0.1"], port=8080)
+    assert get_startup_webui_bind_address(missing_path) == BindAddress(hosts=["127.0.0.1", "::1"], port=8001)
 
 
 def test_startup_bindings_can_read_addresses_from_bot_config(tmp_path: Path):
@@ -37,8 +37,8 @@ port = 18001
         encoding="utf-8",
     )
 
-    assert get_startup_main_bind_address(config_path) == BindAddress(host="0.0.0.0", port=22345)
-    assert get_startup_webui_bind_address(config_path) == BindAddress(host="192.168.1.9", port=18001)
+    assert get_startup_main_bind_address(config_path) == BindAddress(hosts=["0.0.0.0"], port=22345)
+    assert get_startup_webui_bind_address(config_path) == BindAddress(hosts=["192.168.1.9"], port=18001)
 
 
 def test_resolve_bindings_prefer_initialized_global_config(monkeypatch):
@@ -51,8 +51,8 @@ def test_resolve_bindings_prefer_initialized_global_config(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "src.config.config", fake_config_module)
 
-    assert resolve_main_bind_address() == BindAddress(host="10.0.0.2", port=32000)
-    assert resolve_webui_bind_address() == BindAddress(host="10.0.0.3", port=32001)
+    assert resolve_main_bind_address() == BindAddress(hosts=["10.0.0.2"], port=32000)
+    assert resolve_webui_bind_address() == BindAddress(hosts=["10.0.0.3"], port=32001)
 
 
 def test_legacy_env_bindings_are_migrated_when_fields_missing_or_default(monkeypatch):
@@ -64,7 +64,7 @@ def test_legacy_env_bindings_are_migrated_when_fields_missing_or_default(monkeyp
     payload = {
         "maim_message": {
             "ws_server_host": "127.0.0.1",
-            "ws_server_port": 8080,
+            "ws_server_port": 8000,
         },
         "webui": {},
     }

--- a/pytests/image_sys_test/image_manager_test.py
+++ b/pytests/image_sys_test/image_manager_test.py
@@ -7,6 +7,9 @@ import importlib.util
 
 
 class DummyLogger:
+    def debug(self, *a, **k):
+        pass
+
     def info(self, *a, **k):
         pass
 
@@ -87,7 +90,7 @@ class DummyMaiImage:
 
     async def calculate_hash_format(self):
         self.file_hash = "dummy-hash"
-        return None
+        return True
 
 
 class DummyLLMRequest:
@@ -196,6 +199,17 @@ def patch_external_dependencies(monkeypatch):
 
     llm_options_mod = types.SimpleNamespace(LLMImageOptions=lambda **kwargs: types.SimpleNamespace(**kwargs))
     monkeypatch.setitem(sys.modules, "src.common.data_models.llm_service_data_models", llm_options_mod)
+
+    # Patch config_manager to make _is_vlm_task_configured return True
+    mock_model_config = types.SimpleNamespace(
+        model_task_config=types.SimpleNamespace(
+            vlm=types.SimpleNamespace(model_list=["mock-vlm-model"])
+        )
+    )
+    config_mgr_mod = types.SimpleNamespace(
+        config_manager=types.SimpleNamespace(get_model_config=lambda: mock_model_config)
+    )
+    monkeypatch.setitem(sys.modules, "src.config.config", config_mgr_mod)
 
     # If module already imported, reload it to apply patches
     mod_name = "src.chat.image_system.image_manager"

--- a/pytests/message_test/session_message_test.py
+++ b/pytests/message_test/session_message_test.py
@@ -58,7 +58,7 @@ class DummyDBSession:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def exec(self, statement):
+    def exec(self, statement, *args, **kwargs):
         return self
 
     def first(self):
@@ -71,11 +71,11 @@ class DummyDBSession:
         return []
 
 
-def get_db_session():
+def get_db_session(*args, **kwargs):
     return DummyDBSession()
 
 
-def get_manual_db_session():
+def get_manual_db_session(*args, **kwargs):
     return DummyDBSession()
 
 
@@ -122,8 +122,14 @@ def setup_mocks(monkeypatch):
     db_mod.get_db_session = get_db_session
     db_mod.get_manual_db_session = get_manual_db_session
 
-    db_model_mod = _stub_module("src.common.database.database_model")
-    db_model_mod.Messages = None  # 可以根据需要添加更多的属性或方法
+    class DynamicModelModule(ModuleType):
+        def __getattr__(self, name):
+            cls = type(name, (), {})
+            setattr(self, name, cls)
+            return cls
+
+    db_model_mod = DynamicModelModule("src.common.database.database_model")
+    monkeypatch.setitem(sys.modules, "src.common.database.database_model", db_model_mod)
 
     emoji_manager_mod = _stub_module("src.emoji_system.emoji_manager")
     emoji_manager_mod.emoji_manager = None  # 可以根据需要添加更多的属性或方法
@@ -136,6 +142,9 @@ def setup_mocks(monkeypatch):
 
     voice_utils_mod = _stub_module("src.common.utils.utils_voice")
     voice_utils_mod.get_voice_text = dummy_get_voice_text
+
+    system_utils_mod = _stub_module("src.common.utils.system_utils")
+    system_utils_mod.is_bot_self = lambda *a, **k: False
 
     person_utils_mod = _stub_module("src.common.utils.utils_person")
     person_utils_mod.PersonUtils = DummyPersonUtils
@@ -202,7 +211,8 @@ async def test_image(monkeypatch):
     msg.raw_message = MessageSequence(components=[])
     msg.raw_message.components = [ImageComponent(binary_hash="image_hash"), TextComponent("Hello, world!")]
     await msg.process()
-    assert msg.processed_plain_text == "[一张图片，网卡了加载不出来] Hello, world!"
+    # 待识别或无描述图片保持空串，由上层渲染占位
+    assert msg.processed_plain_text == " Hello, world!"
 
 
 @pytest.mark.asyncio
@@ -213,7 +223,7 @@ async def test_emoji(monkeypatch):
     msg.raw_message = MessageSequence(components=[])
     msg.raw_message.components = [EmojiComponent(binary_hash="emoji_hash"), TextComponent("Hello, world!")]
     await msg.process()
-    assert msg.processed_plain_text == "[一个表情，网卡了加载不出来] Hello, world!"
+    assert msg.processed_plain_text == "[表情包] Hello, world!"
 
 
 @pytest.mark.asyncio

--- a/pytests/plugin_runtime/test_plugin_type_filter.py
+++ b/pytests/plugin_runtime/test_plugin_type_filter.py
@@ -22,7 +22,7 @@ def _write_plugin_with_type_key(root: Path, name: str, plugin_type: str, type_ke
                 "author": {"name": "MaiBot", "url": "https://example.com"},
                 "license": "GPL-v3.0-or-later",
                 "urls": {"repository": "https://example.com/repo"},
-                "host_application": {"min_version": "1.0.0", "max_version": "1.1.99"},
+                "host_application": {"min_version": "1.0.0", "max_version": "1.99.99"},
                 "sdk": {"min_version": "2.0.0", "max_version": "2.99.99"},
                 "dependencies": [],
                 "capabilities": [],

--- a/pytests/webui/test_jargon_routes.py
+++ b/pytests/webui/test_jargon_routes.py
@@ -622,6 +622,7 @@ def test_get_chat_list_includes_chat_session_without_jargon(client: TestClient, 
             "session_id": sample_chat_session.session_id,
             "chat_name": sample_chat_session.group_name,
             "platform": sample_chat_session.platform,
+            "account_id": sample_chat_session.account_id,
             "is_group": True,
         }
     ]

--- a/pytests/webui/test_model_routes.py
+++ b/pytests/webui/test_model_routes.py
@@ -98,6 +98,7 @@ async def test_test_provider_connection_uses_query_api_key_for_gemini(
         calls=calls,
     )
     monkeypatch.setattr(model_routes.httpx, "AsyncClient", fake_client_class)
+    monkeypatch.setattr(model_routes, "validate_public_url", lambda url, **kw: url)
 
     result = await model_routes.test_provider_connection(
         base_url="https://generativelanguage.googleapis.com/v1beta",
@@ -134,6 +135,7 @@ async def test_test_provider_connection_uses_bearer_auth_for_openai_compatible(
         calls=calls,
     )
     monkeypatch.setattr(model_routes.httpx, "AsyncClient", fake_client_class)
+    monkeypatch.setattr(model_routes, "validate_public_url", lambda url, **kw: url)
 
     result = await model_routes.test_provider_connection(
         base_url="https://example.com/v1",

--- a/pytests/webui/test_plugin_management_routes.py
+++ b/pytests/webui/test_plugin_management_routes.py
@@ -235,6 +235,8 @@ def test_install_plugin_preserves_manifest_declared_id(client: TestClient, monke
                         "name": "Declared Plugin",
                         "version": "1.0.0",
                         "author": {"name": "author"},
+                        "host_application": {"min_version": "1.0.0", "max_version": "1.99.99"},
+                        "sdk": {"min_version": "2.0.0", "max_version": "2.99.99"},
                     }
                 ),
                 encoding="utf-8",
@@ -271,6 +273,8 @@ def test_install_plugin_backfills_missing_manifest_id(client: TestClient, monkey
                         "name": "Legacy Plugin",
                         "version": "1.0.0",
                         "author": {"name": "author"},
+                        "host_application": {"min_version": "1.0.0", "max_version": "1.99.99"},
+                        "sdk": {"min_version": "2.0.0", "max_version": "2.99.99"},
                     }
                 ),
                 encoding="utf-8",
@@ -360,6 +364,7 @@ def test_clone_repository_reports_plugin_and_mirror_progress(tmp_path, monkeypat
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     service = mirror_service_module.GitMirrorService(max_retries=1, timeout=1, config=FakeMirrorConfig())
+    monkeypatch.setattr(mirror_service_module, "validate_public_url", lambda url, **kw: url)
     monkeypatch.setattr(mirror_service_module.subprocess, "run", fake_run)
     mirror_service_module.set_update_progress_callback(collect_progress)
 

--- a/src/A_memorix/core/embedding/api_adapter.py
+++ b/src/A_memorix/core/embedding/api_adapter.py
@@ -33,6 +33,9 @@ class EmbeddingAPIAdapter:
 
     _GLOBAL_DIMENSION_CACHE: Dict[str, int] = {}
     _GLOBAL_TEXT_EMBEDDING_CACHE: Dict[Tuple[str, int, str], np.ndarray] = {}
+    # 文本向量缓存按唯一文本无界增长（单条可达数 KB），超过上限时
+    # 按插入顺序淘汰最旧条目，防止长期运行内存无界增长。
+    MAX_TEXT_EMBEDDING_CACHE_SIZE = 4096
 
     def __init__(
         self,
@@ -499,6 +502,7 @@ class EmbeddingAPIAdapter:
                     text = batch[batch_index]
                     cache_key = self._embedding_cache_key(text, dimensions)
                     self._GLOBAL_TEXT_EMBEDDING_CACHE[cache_key] = vector.copy()
+                    self._prune_text_embedding_cache()
 
             batch_results.extend(normalized_results)
             batch_results.sort(key=lambda item: item[0])
@@ -523,6 +527,17 @@ class EmbeddingAPIAdapter:
             finally:
                 self.max_concurrent = previous
         return await self.encode(texts, batch_size=batch_size, dimensions=dimensions)
+
+    @classmethod
+    def _prune_text_embedding_cache(cls) -> None:
+        """把文本向量缓存裁剪到容量上限内（按插入顺序淘汰最旧条目）。"""
+
+        cache = cls._GLOBAL_TEXT_EMBEDDING_CACHE
+        overflow = len(cache) - cls.MAX_TEXT_EMBEDDING_CACHE_SIZE
+        if overflow <= 0:
+            return
+        for key in list(cache)[:overflow]:
+            cache.pop(key, None)
 
     def get_embedding_dimension(self) -> int:
         if self._dimension is not None:

--- a/src/A_memorix/core/embedding/manager.py
+++ b/src/A_memorix/core/embedding/manager.py
@@ -367,6 +367,7 @@ class EmbeddingManager:
         with self._cache_lock:
             with np.load(cache_path, allow_pickle=False) as data:
                 self._embedding_cache = {str(key): np.asarray(data[key], dtype=np.float32) for key in data.files}
+            self._prune_embedding_cache()
 
             logger.info(f"缓存已加载: {cache_path} ({len(self._embedding_cache)} 条)")
 

--- a/src/A_memorix/core/embedding/manager.py
+++ b/src/A_memorix/core/embedding/manager.py
@@ -290,6 +290,7 @@ class EmbeddingManager:
                 for text, embedding in zip(uncached_texts, new_embeddings, strict=True):
                     cache_key = self._get_cache_key(text)
                     self._embedding_cache[cache_key] = embedding.copy()
+                self._prune_embedding_cache()
 
             # 合并结果
             for idx, embedding in zip(uncached_indices, new_embeddings, strict=True):
@@ -300,6 +301,19 @@ class EmbeddingManager:
         final_embeddings = np.array([emb for _, emb in cached_embeddings])
 
         return final_embeddings
+
+    # 内存缓存按唯一文本无界增长（单条向量可达数 KB），超过上限时
+    # 按插入顺序淘汰最旧条目；落盘缓存（save_cache）不受影响。
+    MAX_EMBEDDING_CACHE_SIZE = 10000
+
+    def _prune_embedding_cache(self) -> None:
+        """把内存嵌入缓存裁剪到容量上限内（需持有 ``self._cache_lock``）。"""
+
+        overflow = len(self._embedding_cache) - self.MAX_EMBEDDING_CACHE_SIZE
+        if overflow <= 0:
+            return
+        for cache_key in list(self._embedding_cache)[:overflow]:
+            self._embedding_cache.pop(cache_key, None)
 
     def save_cache(self, cache_path: Optional[Union[str, Path]] = None) -> None:
         """

--- a/src/A_memorix/core/runtime/services/background_task_service.py
+++ b/src/A_memorix/core/runtime/services/background_task_service.py
@@ -426,6 +426,13 @@ class MemoryBackgroundTaskService(KernelServiceBase):
                 active_window_hours = max(1.0, float(self._cfg("person_profile.active_window_hours", 72.0) or 72.0))
                 max_refresh = max(1, int(self._cfg("person_profile.max_refresh_per_cycle", 50) or 50))
                 cutoff = time.time() - active_window_hours * 3600.0
+                # 顺手清理窗口外的时间戳：这些条目永远不会再次命中候选，
+                # 不清理会让字典随历史人物数无界增长。
+                stale_person_ids = [
+                    person_id for person_id, seen_at in self._active_person_timestamps.items() if seen_at < cutoff
+                ]
+                for person_id in stale_person_ids:
+                    self._active_person_timestamps.pop(person_id, None)
                 candidates = [
                     person_id
                     for person_id, seen_at in sorted(

--- a/src/A_memorix/core/utils/retrieval_tuning_manager.py
+++ b/src/A_memorix/core/utils/retrieval_tuning_manager.py
@@ -688,6 +688,33 @@ class RetrievalTuningManager:
     def _pending_task_count(self) -> int:
         return sum(1 for t in self._tasks.values() if t.status in {"queued", "running", "cancel_requested"})
 
+    # 内存中保留的任务记录数量上限：任务记录含最多 200 轮的 profile/metrics
+    # 深拷贝（单任务可达几十至几百 KB），超限后按插入顺序淘汰最旧的
+    # 已完成/已取消/已失败任务，防止字典随历史任务数无界增长。
+    MAX_RETAINED_FINISHED_TASKS = 50
+
+    def _prune_finished_tasks_locked(self) -> None:
+        """把内存任务记录裁剪到容量上限内（需持有 ``self._lock``）。只淘汰终态任务。"""
+
+        overflow = len(self._tasks) - self.MAX_RETAINED_FINISHED_TASKS
+        if overflow <= 0:
+            return
+        finished_statuses = {"completed", "failed", "cancelled"}
+        removed_count = 0
+        # _task_order 新任务在左侧，从最旧的一端开始淘汰。
+        for task_id in list(reversed(self._task_order)):
+            if removed_count >= overflow:
+                break
+            task = self._tasks.get(task_id)
+            if task is None or task.status not in finished_statuses:
+                continue
+            self._tasks.pop(task_id, None)
+            try:
+                self._task_order.remove(task_id)
+            except ValueError:
+                pass
+            removed_count += 1
+
     def _sample_triples_for_query_set(
         self,
         *,
@@ -1022,6 +1049,7 @@ class RetrievalTuningManager:
                 task.finished_at = _now()
                 task.updated_at = task.finished_at
                 self._queue = deque([x for x in self._queue if x != task_id])
+                self._prune_finished_tasks_locked()
                 return task.to_summary()
             task.status = "cancel_requested"
             task.cancel_requested = True
@@ -1113,6 +1141,7 @@ class RetrievalTuningManager:
                 async with self._lock:
                     if self._active_task_id == task_id:
                         self._active_task_id = None
+                    self._prune_finished_tasks_locked()
 
     async def _run_task(self, task_id: str) -> None:
         async with self._lock:

--- a/src/A_memorix/core/utils/summary_importer.py
+++ b/src/A_memorix/core/utils/summary_importer.py
@@ -703,9 +703,12 @@ class SummaryImporter:
                 metadata=metadata,
             )
 
-            # 7. 持久化
-            if self.vector_store is not None:
-                self.vector_store.save()
+            # 7. 持久化（同时保存主向量库与独立的图向量库，避免重复调用相同实例）
+            saved_stores: set[int] = set()
+            for store in (self.vector_store, self._graph_vector_store()):
+                if store is not None and id(store) not in saved_stores:
+                    store.save()
+                    saved_stores.add(id(store))
             if self.graph_store is not None:
                 self.graph_store.save()
 
@@ -815,6 +818,13 @@ class SummaryImporter:
             logger.warning(f"非法 summarization.default_knowledge_type={type_str}，回退 narrative")
             knowledge_type = KnowledgeType.NARRATIVE
 
+        # 在写入 metadata_store 之前前置校验向量依赖，避免在不可回滚时留下悬空段落
+        vector_writer = getattr(plugin_instance, "write_paragraph_vector_or_enqueue", None)
+        if not callable(vector_writer):
+            if (self.vector_store is None or self.embedding_manager is None) and not self._allow_metadata_only_write():
+                missing_dep = "vector_store" if self.vector_store is None else "embedding_manager"
+                raise RuntimeError(f"总结导入前置依赖检查失败: {missing_dep} 不可用且未开启 metadata_only 回退")
+
         # 导入总结文本
         hash_value = self.metadata_store.add_paragraph(
             content=summary,
@@ -824,7 +834,6 @@ class SummaryImporter:
             time_meta=time_meta,
         )
 
-        vector_writer = getattr(plugin_instance, "write_paragraph_vector_or_enqueue", None)
         if callable(vector_writer):
             result = await vector_writer(
                 paragraph_hash=hash_value,
@@ -839,9 +848,11 @@ class SummaryImporter:
                     embedding = await self.embedding_manager.encode(summary)
                     self.vector_store.add(vectors=embedding.reshape(1, -1), ids=[hash_value])
                 elif not self._allow_metadata_only_write():
-                    raise RuntimeError("vector_store 或 embedding_manager 不可用")
+                    missing_dep = "vector_store" if self.vector_store is None else "embedding_manager"
+                    raise RuntimeError(f"{missing_dep} 不可用")
                 else:
-                    self.metadata_store.enqueue_paragraph_vector_backfill(hash_value, error="vector_store_unavailable")
+                    error_reason = "vector_store_unavailable" if self.vector_store is None else "embedding_manager_unavailable"
+                    self.metadata_store.enqueue_paragraph_vector_backfill(hash_value, error=error_reason)
             except Exception as exc:
                 if not self._allow_metadata_only_write():
                     raise
@@ -851,12 +862,19 @@ class SummaryImporter:
         # 导入实体
         normalized_entities = _normalize_entity_items(entities)
         if normalized_entities:
-            with self.metadata_store.transaction(immediate=True), self.graph_store.batch_update():
-                self.graph_store.add_nodes(normalized_entities)
-                entity_hashes = self.metadata_store.add_entities_batch(
-                    normalized_entities,
-                    source_paragraph=hash_value,
-                )
+            if self.graph_store is not None:
+                with self.metadata_store.transaction(immediate=True), self.graph_store.batch_update():
+                    self.graph_store.add_nodes(normalized_entities)
+                    entity_hashes = self.metadata_store.add_entities_batch(
+                        normalized_entities,
+                        source_paragraph=hash_value,
+                    )
+            else:
+                with self.metadata_store.transaction(immediate=True):
+                    entity_hashes = self.metadata_store.add_entities_batch(
+                        normalized_entities,
+                        source_paragraph=hash_value,
+                    )
             entity_vector_items = list(zip(entity_hashes, normalized_entities, strict=True))
             await self._ensure_entity_vectors(entity_vector_items)
 
@@ -878,7 +896,7 @@ class SummaryImporter:
                     source_paragraph=hash_value,
                     write_vector=write_vector,
                 )
-            else:
+            elif self.graph_store is not None:
                 with self.metadata_store.transaction(immediate=True), self.graph_store.batch_update():
                     # 写入元数据和图数据库（保留 relation_hashes，确保后续可按关系精确修剪）
                     relation_hashes = self.metadata_store.add_relations_batch(
@@ -889,6 +907,13 @@ class SummaryImporter:
                     self.graph_store.add_edges(
                         [(subject, obj) for subject, _, obj in relation_tuples],
                         relation_hashes=relation_hashes,
+                    )
+            else:
+                with self.metadata_store.transaction(immediate=True):
+                    self.metadata_store.add_relations_batch(
+                        relation_tuples,
+                        confidence=1.0,
+                        source_paragraph=hash_value,
                     )
 
         logger.info(f"总结导入完成: hash={hash_value[:8]}")

--- a/src/A_memorix/core/utils/summary_importer.py
+++ b/src/A_memorix/core/utils/summary_importer.py
@@ -257,8 +257,12 @@ class SummaryImporter:
         target_store = self._graph_vector_store()
         if target_store is None or self.embedding_manager is None:
             if not self._allow_metadata_only_write():
-                missing_dep = "graph_vector_store" if target_store is None else "embedding_manager"
-                raise RuntimeError(f"实体向量依赖缺失: {missing_dep} 不可用且未开启 metadata_only 模式")
+                missing_deps = [
+                    dep
+                    for dep, obj in (("graph_vector_store", target_store), ("embedding_manager", self.embedding_manager))
+                    if obj is None
+                ]
+                raise RuntimeError(f"实体向量依赖缺失: {' 与 '.join(missing_deps)} 不可用且未开启 metadata_only 模式")
             logger.warning(
                 "实体向量依赖不可用，跳过实体向量写入并保留 metadata/graph: "
                 f"store_ready={target_store is not None} embedding_ready={self.embedding_manager is not None}"
@@ -833,8 +837,12 @@ class SummaryImporter:
         vector_writer = getattr(plugin_instance, "write_paragraph_vector_or_enqueue", None)
         if not callable(vector_writer):
             if (self.vector_store is None or self.embedding_manager is None) and not self._allow_metadata_only_write():
-                missing_dep = "vector_store" if self.vector_store is None else "embedding_manager"
-                raise RuntimeError(f"总结导入前置依赖检查失败: {missing_dep} 不可用且未开启 metadata_only 回退")
+                missing_deps = [
+                    dep
+                    for dep, obj in (("vector_store", self.vector_store), ("embedding_manager", self.embedding_manager))
+                    if obj is None
+                ]
+                raise RuntimeError(f"总结导入前置依赖检查失败: {' 与 '.join(missing_deps)} 不可用且未开启 metadata_only 回退")
 
         # 导入总结文本
         hash_value = self.metadata_store.add_paragraph(
@@ -859,10 +867,19 @@ class SummaryImporter:
                     embedding = await self.embedding_manager.encode(summary)
                     self.vector_store.add(vectors=embedding.reshape(1, -1), ids=[hash_value])
                 elif not self._allow_metadata_only_write():
-                    missing_dep = "vector_store" if self.vector_store is None else "embedding_manager"
-                    raise RuntimeError(f"{missing_dep} 不可用")
+                    missing_deps = [
+                        dep
+                        for dep, obj in (("vector_store", self.vector_store), ("embedding_manager", self.embedding_manager))
+                        if obj is None
+                    ]
+                    raise RuntimeError(f"{' 与 '.join(missing_deps)} 不可用")
                 else:
-                    error_reason = "vector_store_unavailable" if self.vector_store is None else "embedding_manager_unavailable"
+                    missing_reasons = []
+                    if self.vector_store is None:
+                        missing_reasons.append("vector_store_unavailable")
+                    if self.embedding_manager is None:
+                        missing_reasons.append("embedding_manager_unavailable")
+                    error_reason = "+".join(missing_reasons) or "vector_runtime_unavailable"
                     self.metadata_store.enqueue_paragraph_vector_backfill(hash_value, error=error_reason)
             except Exception as exc:
                 if not self._allow_metadata_only_write():

--- a/src/A_memorix/core/utils/summary_importer.py
+++ b/src/A_memorix/core/utils/summary_importer.py
@@ -704,8 +704,10 @@ class SummaryImporter:
             )
 
             # 7. 持久化
-            self.vector_store.save()
-            self.graph_store.save()
+            if self.vector_store is not None:
+                self.vector_store.save()
+            if self.graph_store is not None:
+                self.graph_store.save()
 
             external_id = str((metadata or {}).get("external_id", "") or "").strip()
             if external_id:
@@ -833,8 +835,13 @@ class SummaryImporter:
                 logger.warning(f"总结导入段落进入回退写入: {result}")
         else:
             try:
-                embedding = await self.embedding_manager.encode(summary)
-                self.vector_store.add(vectors=embedding.reshape(1, -1), ids=[hash_value])
+                if self.vector_store is not None and self.embedding_manager is not None:
+                    embedding = await self.embedding_manager.encode(summary)
+                    self.vector_store.add(vectors=embedding.reshape(1, -1), ids=[hash_value])
+                elif not self._allow_metadata_only_write():
+                    raise RuntimeError("vector_store 或 embedding_manager 不可用")
+                else:
+                    self.metadata_store.enqueue_paragraph_vector_backfill(hash_value, error="vector_store_unavailable")
             except Exception as exc:
                 if not self._allow_metadata_only_write():
                     raise

--- a/src/A_memorix/core/utils/summary_importer.py
+++ b/src/A_memorix/core/utils/summary_importer.py
@@ -255,6 +255,16 @@ class SummaryImporter:
             return
 
         target_store = self._graph_vector_store()
+        if target_store is None or self.embedding_manager is None:
+            if not self._allow_metadata_only_write():
+                missing_dep = "graph_vector_store" if target_store is None else "embedding_manager"
+                raise RuntimeError(f"实体向量依赖缺失: {missing_dep} 不可用且未开启 metadata_only 模式")
+            logger.warning(
+                "实体向量依赖不可用，跳过实体向量写入并保留 metadata/graph: "
+                f"store_ready={target_store is not None} embedding_ready={self.embedding_manager is not None}"
+            )
+            return
+
         pending_entities: List[Tuple[str, str, str]] = []
         for entity_hash, name in entities:
             token = str(entity_hash or "").strip()
@@ -703,15 +713,7 @@ class SummaryImporter:
                 metadata=metadata,
             )
 
-            # 7. 持久化（同时保存主向量库与独立的图向量库，避免重复调用相同实例）
-            saved_stores: set[int] = set()
-            for store in (self.vector_store, self._graph_vector_store()):
-                if store is not None and id(store) not in saved_stores:
-                    store.save()
-                    saved_stores.add(id(store))
-            if self.graph_store is not None:
-                self.graph_store.save()
-
+            # 先写入外部引用标记建立幂等索引，确保保存或后续步骤异常时重试可精准去重
             external_id = str((metadata or {}).get("external_id", "") or "").strip()
             if external_id:
                 self.metadata_store.upsert_external_memory_ref(
@@ -720,6 +722,15 @@ class SummaryImporter:
                     source_type="chat_summary",
                     metadata={"chat_id": stream_id},
                 )
+
+            # 7. 持久化（同时保存主向量库与独立的图向量库，避免重复调用相同实例）
+            saved_stores: set[int] = set()
+            for store in (self.vector_store, self._graph_vector_store()):
+                if store is not None and id(store) not in saved_stores:
+                    store.save()
+                    saved_stores.add(id(store))
+            if self.graph_store is not None:
+                self.graph_store.save()
 
             result_msg = f"总结导入成功|长度: {len(summary_text)}|实体: {len(entities)}|关系: {len(relations)}"
             return SummaryImportResult(

--- a/src/A_memorix/core/utils/web_import_manager.py
+++ b/src/A_memorix/core/utils/web_import_manager.py
@@ -395,6 +395,10 @@ class ImportTaskRecord:
 
 
 class ImportTaskManager:
+    # 内存中保留的任务记录数量上限：任务记录含文件与分块明细，
+    # 超限后按插入顺序淘汰最旧的已完成/已取消/已失败任务，防止字典无界增长。
+    MAX_RETAINED_FINISHED_TASKS = 50
+
     def __init__(self, plugin: Any):
         self.plugin = plugin
         self._lock = asyncio.Lock()
@@ -2347,6 +2351,7 @@ class ImportTaskManager:
                 task.current_step = "completed"
             task.finished_at = _now()
             task.updated_at = _now()
+            self._prune_finished_tasks_locked()
             self._try_write_task_report(task)
             task_kind = str(task.params.get("task_kind") or task.source).strip().lower()
             write_task_kinds = {"upload", "paste", "raw_scan", "lpmm_openie", "maibot_migration", "lpmm_convert"}
@@ -4504,3 +4509,29 @@ JSON schema:
         task.finished_at = _now()
         task.updated_at = _now()
         self._recompute_task_progress(task)
+        self._prune_finished_tasks_locked()
+
+    def _prune_finished_tasks_locked(self) -> None:
+        """把内存任务记录裁剪到容量上限内（需持有 ``self._lock``）。
+
+        只淘汰已到终态的任务；活跃与排队中的任务不受影响。
+        """
+
+        overflow = len(self._tasks) - self.MAX_RETAINED_FINISHED_TASKS
+        if overflow <= 0:
+            return
+        finished_statuses = {"completed", "completed_with_errors", "cancelled", "failed"}
+        removed_count = 0
+        # _task_order 新任务在左侧，从最旧的一端开始淘汰。
+        for task_id in list(reversed(self._task_order)):
+            if removed_count >= overflow:
+                break
+            task = self._tasks.get(task_id)
+            if task is None or task.status not in finished_statuses:
+                continue
+            self._tasks.pop(task_id, None)
+            try:
+                self._task_order.remove(task_id)
+            except ValueError:
+                pass
+            removed_count += 1

--- a/src/A_memorix/core/utils/web_import_manager.py
+++ b/src/A_memorix/core/utils/web_import_manager.py
@@ -2115,7 +2115,7 @@ class ImportTaskManager:
     async def shutdown(self) -> None:
         async with self._lock:
             self._stopping = True
-            for task in self._tasks.values():
+            for task in list(self._tasks.values()):
                 if task.status in {"queued", "preparing", "running", "cancel_requested"}:
                     task.cancel_requested_at = _now()
                     task.cancel_origin = "runtime_shutdown"

--- a/src/A_memorix/scripts/convert_lpmm.py
+++ b/src/A_memorix/scripts/convert_lpmm.py
@@ -192,12 +192,15 @@ class LPMMConverter:
     def _load_plugin_config(self) -> Dict[str, Any]:
         config_path = DEFAULT_CONFIG_PATH
         if not config_path.exists():
-            raise FileNotFoundError(f"A_Memorix 配置不存在，无法确定 Embedding 指纹: {config_path}")
-        with open(config_path, "r", encoding="utf-8") as f:
-            parsed = tomlkit.load(f)
-        if not isinstance(parsed, dict):
-            raise TypeError(f"A_Memorix 配置根节点必须是对象: {config_path}")
-        return dict(parsed)
+            return {}
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                parsed = tomlkit.load(f)
+            if not isinstance(parsed, dict):
+                return {}
+            return dict(parsed)
+        except Exception:
+            return {}
 
     def _load_embedding_fingerprint(self) -> Dict[str, Any]:
         cfg = self._load_plugin_config()

--- a/src/A_memorix/scripts/convert_lpmm.py
+++ b/src/A_memorix/scripts/convert_lpmm.py
@@ -193,14 +193,11 @@ class LPMMConverter:
         config_path = DEFAULT_CONFIG_PATH
         if not config_path.exists():
             return {}
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                parsed = tomlkit.load(f)
-            if not isinstance(parsed, dict):
-                return {}
-            return dict(parsed)
-        except Exception:
-            return {}
+        with open(config_path, "r", encoding="utf-8") as f:
+            parsed = tomlkit.load(f)
+        if not isinstance(parsed, dict):
+            raise TypeError(f"A_Memorix 配置根节点必须是对象: {config_path}")
+        return dict(parsed)
 
     def _load_embedding_fingerprint(self) -> Dict[str, Any]:
         cfg = self._load_plugin_config()

--- a/src/chat/heart_flow/heartflow_manager.py
+++ b/src/chat/heart_flow/heartflow_manager.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from typing import Dict
+from weakref import WeakValueDictionary
 
 import asyncio
 import time
@@ -20,7 +21,8 @@ class HeartflowManager:
 
     def __init__(self) -> None:
         self.heartflow_chat_list: OrderedDict[str, MaisakaHeartFlowChatting] = OrderedDict()
-        self._chat_create_locks: Dict[str, asyncio.Lock] = {}
+        # 使用弱值字典保存会话创建锁：等待中的协程持有强引用，锁用完且无人引用时自动回收，避免按 session 无限累积。
+        self._chat_create_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
         self._chat_last_active_at: Dict[str, float] = {}
 
     async def get_or_create_heartflow_chat(self, session_id: str) -> MaisakaHeartFlowChatting:
@@ -30,7 +32,7 @@ class HeartflowManager:
                 self._touch_chat(session_id)
                 return chat
 
-            create_lock = self._chat_create_locks.setdefault(session_id, asyncio.Lock())
+            create_lock = self._borrow_create_lock(session_id)
             async with create_lock:
                 if chat := self.heartflow_chat_list.get(session_id):
                     self._touch_chat(session_id)
@@ -79,9 +81,6 @@ class HeartflowManager:
         """停止并移除指定会话的心流实例。"""
         chat = self.heartflow_chat_list.pop(session_id, None)
         self._chat_last_active_at.pop(session_id, None)
-        lock = self._chat_create_locks.get(session_id)
-        if lock is not None and not lock.locked():
-            self._chat_create_locks.pop(session_id, None)
         if chat is None:
             return
 
@@ -91,13 +90,32 @@ class HeartflowManager:
         except Exception as exc:
             logger.warning(f"淘汰心流聊天 {session_id} 失败: {exc}", exc_info=True)
 
+    def _borrow_create_lock(self, session_id: str) -> asyncio.Lock:
+        """获取指定会话的创建锁；弱值字典在无人引用时自动回收条目。"""
+        create_lock = self._chat_create_locks.get(session_id)
+        if create_lock is None:
+            create_lock = asyncio.Lock()
+            self._chat_create_locks[session_id] = create_lock
+        return create_lock
+
+    async def release_chat(self, session_id: str, *, reason: str) -> None:
+        """停止并移除指定会话的心流实例及其活跃时间簿记（供聊天流删除、CLI 退出等外部场景调用）。
+
+        与 ``get_or_create_heartflow_chat`` 基于同一把创建锁串行化，
+        避免释放完成后，并发进行中的创建流程又把运行时写回列表（复活已删除会话）。
+        外部不应直接操作 ``heartflow_chat_list``，否则会遗留运行中的后台任务和簿记数据。
+        """
+        async with self._borrow_create_lock(session_id):
+            await self._evict_chat(session_id, reason=reason)
+
     async def clear_chat_history_context(self, session_id: str) -> bool:
         """停止并移除当前会话运行时，使其短期历史上下文立即失效。"""
 
         if session_id not in self.heartflow_chat_list:
             return False
 
-        await self._evict_chat(session_id, reason="clear_context_command")
+        async with self._borrow_create_lock(session_id):
+            await self._evict_chat(session_id, reason="clear_context_command")
         return True
 
     def adjust_talk_frequency(self, session_id: str, frequency: float) -> None:

--- a/src/chat/heart_flow/heartflow_manager.py
+++ b/src/chat/heart_flow/heartflow_manager.py
@@ -109,14 +109,17 @@ class HeartflowManager:
             await self._evict_chat(session_id, reason=reason)
 
     async def clear_chat_history_context(self, session_id: str) -> bool:
-        """停止并移除当前会话运行时，使其短期历史上下文立即失效。"""
+        """停止并移除当前会话运行时，使其短期历史上下文立即失效。
 
-        if session_id not in self.heartflow_chat_list:
-            return False
-
+        与创建流程共用同一把会话锁，并在锁内检查运行时是否存在：
+        避免创建流程持锁停在 ``await new_chat.start()`` 时，此处锁外检查误判为不存在，
+        随后创建流程又把运行时写回列表的竞态。
+        """
         async with self._borrow_create_lock(session_id):
+            if session_id not in self.heartflow_chat_list:
+                return False
             await self._evict_chat(session_id, reason="clear_context_command")
-        return True
+            return True
 
     def adjust_talk_frequency(self, session_id: str, frequency: float) -> None:
         """调整指定聊天流的说话频率。"""

--- a/src/chat/heart_flow/heartflow_manager.py
+++ b/src/chat/heart_flow/heartflow_manager.py
@@ -15,6 +15,8 @@ logger = get_logger("heartflow")
 
 HEARTFLOW_ACTIVE_RETENTION_SECONDS = 24 * 60 * 60
 HEARTFLOW_MAX_ACTIVE_CHATS = 100
+HEARTFLOW_DRAIN_TIMEOUT_SECONDS = 30.0
+"""等待在途使用者结束的时限：超时视为租约泄漏，保留运行时并向上抛出异常。"""
 
 
 class HeartflowManager:
@@ -59,6 +61,8 @@ class HeartflowManager:
         async with self._borrow_create_lock(session_id):
             chat = await self._get_or_create_locked(session_id)
             self._acquire_chat_usage(session_id)
+        # 锁外触发上限淘汰：淘汰需要逐个获取其他会话的创建锁，避免死锁
+        await self._evict_over_limit_chats(protected_session_id=session_id)
         try:
             yield chat
         finally:
@@ -83,10 +87,20 @@ class HeartflowManager:
             self._chat_usage_counts[session_id] = count - 1
 
     async def _wait_chat_drained(self, session_id: str) -> None:
-        """等待指定会话的在途使用者全部结束。"""
+        """等待指定会话的在途使用者全部结束。
+
+        超过 :data:`HEARTFLOW_DRAIN_TIMEOUT_SECONDS` 仍未排空视为租约泄漏，
+        抛出 ``TimeoutError`` 并保留现场，避免释放流程持锁无限阻塞。
+        """
         while self._chat_usage_counts.get(session_id, 0) > 0:
             drain_event = self._chat_drain_events.setdefault(session_id, asyncio.Event())
-            await drain_event.wait()
+            try:
+                await asyncio.wait_for(drain_event.wait(), timeout=HEARTFLOW_DRAIN_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError as exc:
+                raise TimeoutError(
+                    f"等待会话 {session_id} 的在途使用者结束超时"
+                    f"（{HEARTFLOW_DRAIN_TIMEOUT_SECONDS}s），可能存在未释放的使用租约"
+                ) from exc
 
     async def _get_or_create_locked(self, session_id: str) -> MaisakaHeartFlowChatting:
         """获取或创建运行时；调用方必须已持有该会话的创建锁。"""
@@ -167,6 +181,8 @@ class HeartflowManager:
 
         self.heartflow_chat_list.pop(session_id, None)
         self._chat_last_active_at.pop(session_id, None)
+        # 等待方在 await 前已持有事件的本地引用，此处回收条目是安全的，避免簿记按 session 无限累积
+        self._chat_drain_events.pop(session_id, None)
         logger.info(f"已淘汰心流聊天 {session_id}: reason={reason}")
         return True
 

--- a/src/chat/heart_flow/heartflow_manager.py
+++ b/src/chat/heart_flow/heartflow_manager.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from typing import Dict
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict
 from weakref import WeakValueDictionary
 
 import asyncio
@@ -24,34 +25,84 @@ class HeartflowManager:
         # 使用弱值字典保存会话创建锁：等待中的协程持有强引用，锁用完且无人引用时自动回收，避免按 session 无限累积。
         self._chat_create_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
         self._chat_last_active_at: Dict[str, float] = {}
+        self._chat_usage_counts: Dict[str, int] = {}
+        """会话运行时的在途使用者计数：淘汰与释放需等待归零，避免运行时停止后仍被写入缓存。"""
+        self._chat_drain_events: Dict[str, asyncio.Event] = {}
+        """使用者计数归零时置位的事件，供淘汰流程等待排空。"""
 
     async def get_or_create_heartflow_chat(self, session_id: str) -> MaisakaHeartFlowChatting:
-        """获取或创建指定会话对应的 Maisaka runtime。"""
+        """获取或创建指定会话对应的 Maisaka runtime。
+
+        注意：返回的运行时不携带使用租约，跨 ``await`` 持有它的调用方
+        应改用 :meth:`borrow_chat`，否则释放/淘汰流程可能在持有期间停止运行时。
+        """
         try:
-            if chat := self.heartflow_chat_list.get(session_id):
-                self._touch_chat(session_id)
-                return chat
-
-            create_lock = self._borrow_create_lock(session_id)
-            async with create_lock:
-                if chat := self.heartflow_chat_list.get(session_id):
-                    self._touch_chat(session_id)
-                    return chat
-
-                chat_session = chat_manager.get_session_by_session_id(session_id)
-                if not chat_session:
-                    raise ValueError(f"未找到 session_id={session_id} 对应的聊天流")
-
-                new_chat = MaisakaHeartFlowChatting(session_id=session_id)
-                await new_chat.start()
-                self.heartflow_chat_list[session_id] = new_chat
-                self._touch_chat(session_id)
-                await self._evict_over_limit_chats(protected_session_id=session_id)
-                return new_chat
+            async with self._borrow_create_lock(session_id):
+                chat = await self._get_or_create_locked(session_id)
+            # 创建完成后在锁外触发上限淘汰：淘汰需要逐个获取其他会话的创建锁，
+            # 若在本会话锁内进行，两个互为淘汰目标的会话可能相互等待造成死锁。
+            await self._evict_over_limit_chats(protected_session_id=session_id)
+            return chat
         except Exception as exc:
             logger.error(f"创建心流聊天 {session_id} 失败: {exc}", exc_info=True)
             traceback.print_exc()
             raise
+
+    @asynccontextmanager
+    async def borrow_chat(self, session_id: str) -> AsyncIterator[MaisakaHeartFlowChatting]:
+        """以使用租约方式借用会话运行时。
+
+        租约在本会话创建锁保护下登记，保证登记时运行时必然在册；
+        租约持有期间 ``release_chat``、历史上下文清理与超限淘汰都会
+        等待本使用者结束后才真正停止运行时。
+        """
+        async with self._borrow_create_lock(session_id):
+            chat = await self._get_or_create_locked(session_id)
+            self._acquire_chat_usage(session_id)
+        try:
+            yield chat
+        finally:
+            self.release_chat_usage(session_id)
+
+    def _acquire_chat_usage(self, session_id: str) -> None:
+        """登记一个在途使用者（必须在本会话创建锁内调用）。"""
+        self._chat_usage_counts[session_id] = self._chat_usage_counts.get(session_id, 0) + 1
+        drain_event = self._chat_drain_events.get(session_id)
+        if drain_event is not None:
+            drain_event.clear()
+
+    def release_chat_usage(self, session_id: str) -> None:
+        """注销一个已结束的在途使用者；计数归零时唤醒等待排空的淘汰流程。"""
+        count = self._chat_usage_counts.get(session_id, 0)
+        if count <= 1:
+            self._chat_usage_counts.pop(session_id, None)
+            drain_event = self._chat_drain_events.get(session_id)
+            if drain_event is not None:
+                drain_event.set()
+        else:
+            self._chat_usage_counts[session_id] = count - 1
+
+    async def _wait_chat_drained(self, session_id: str) -> None:
+        """等待指定会话的在途使用者全部结束。"""
+        while self._chat_usage_counts.get(session_id, 0) > 0:
+            drain_event = self._chat_drain_events.setdefault(session_id, asyncio.Event())
+            await drain_event.wait()
+
+    async def _get_or_create_locked(self, session_id: str) -> MaisakaHeartFlowChatting:
+        """获取或创建运行时；调用方必须已持有该会话的创建锁。"""
+        if chat := self.heartflow_chat_list.get(session_id):
+            self._touch_chat(session_id)
+            return chat
+
+        chat_session = chat_manager.get_session_by_session_id(session_id)
+        if not chat_session:
+            raise ValueError(f"未找到 session_id={session_id} 对应的聊天流")
+
+        new_chat = MaisakaHeartFlowChatting(session_id=session_id)
+        await new_chat.start()
+        self.heartflow_chat_list[session_id] = new_chat
+        self._touch_chat(session_id)
+        return new_chat
 
     def _touch_chat(self, session_id: str) -> None:
         """记录会话最近活跃时间，并维护心流实例的 LRU 顺序。"""
@@ -59,12 +110,28 @@ class HeartflowManager:
         self.heartflow_chat_list.move_to_end(session_id)
 
     async def _evict_over_limit_chats(self, *, protected_session_id: str) -> None:
-        """当实例数量超过上限时，仅淘汰 24 小时内无消息的旧会话。"""
+        """当实例数量超过上限时，仅淘汰 24 小时内无消息的旧会话。
+
+        每个候选会话在其创建锁保护下重验资格后再淘汰，
+        避免等待锁期间该会话已被其他流程删除或重新活跃。
+        """
         while len(self.heartflow_chat_list) > HEARTFLOW_MAX_ACTIVE_CHATS:
             session_id = self._find_evictable_session_id(protected_session_id=protected_session_id)
             if session_id is None:
                 return
-            await self._evict_chat(session_id, reason="cache_limit")
+            async with self._borrow_create_lock(session_id):
+                if session_id not in self.heartflow_chat_list:
+                    continue
+                last_active_at = self._chat_last_active_at.get(session_id, 0.0)
+                if last_active_at > time.time() - HEARTFLOW_ACTIVE_RETENTION_SECONDS:
+                    continue
+                try:
+                    await self._evict_chat_locked(session_id, reason="cache_limit")
+                except Exception as exc:
+                    # 单个会话淘汰失败不阻塞整体流程：刷新活跃时间使其本轮不再满足候选条件，
+                    # 待其空闲后由下次触发重试
+                    logger.warning(f"淘汰心流聊天 {session_id} 失败: {exc}", exc_info=True)
+                    self._touch_chat(session_id)
 
     def _find_evictable_session_id(self, *, protected_session_id: str) -> str | None:
         """按 LRU 查找超过活跃保护窗口的可淘汰会话。"""
@@ -77,18 +144,31 @@ class HeartflowManager:
                 return session_id
         return None
 
-    async def _evict_chat(self, session_id: str, *, reason: str) -> None:
-        """停止并移除指定会话的心流实例。"""
-        chat = self.heartflow_chat_list.pop(session_id, None)
-        self._chat_last_active_at.pop(session_id, None)
-        if chat is None:
-            return
+    async def _evict_chat_locked(self, session_id: str, *, reason: str) -> bool:
+        """停止并移除指定会话的心流实例；调用方必须已持有该会话的创建锁。
 
-        try:
-            await chat.stop()
-            logger.info(f"已淘汰心流聊天 {session_id}: reason={reason}")
-        except Exception as exc:
-            logger.warning(f"淘汰心流聊天 {session_id} 失败: {exc}", exc_info=True)
+        先等待在途使用者归零再停止运行时，且仅在停止成功后才移除列表与簿记；
+        停止失败时保留运行并向上传播异常，避免误报成功或产生第二个运行时。
+
+        Args:
+            session_id: 目标会话 ID。
+            reason: 淘汰原因，用于日志。
+
+        Returns:
+            bool: 会话存在运行时且已成功停止移除时为 True；运行时不存在时为 False。
+        """
+        chat = self.heartflow_chat_list.get(session_id)
+        if chat is None:
+            return False
+
+        # 等待在途使用者（如消息入库流程）结束，避免运行时停止后仍被写入缓存与状态
+        await self._wait_chat_drained(session_id)
+        await chat.stop()
+
+        self.heartflow_chat_list.pop(session_id, None)
+        self._chat_last_active_at.pop(session_id, None)
+        logger.info(f"已淘汰心流聊天 {session_id}: reason={reason}")
+        return True
 
     def _borrow_create_lock(self, session_id: str) -> asyncio.Lock:
         """获取指定会话的创建锁；弱值字典在无人引用时自动回收条目。"""
@@ -102,23 +182,24 @@ class HeartflowManager:
         """停止并移除指定会话的心流实例及其活跃时间簿记（供聊天流删除、CLI 退出等外部场景调用）。
 
         与 ``get_or_create_heartflow_chat`` 基于同一把创建锁串行化，
-        避免释放完成后，并发进行中的创建流程又把运行时写回列表（复活已删除会话）。
+        避免释放完成后，并发进行中的创建流程又把运行时写回列表（复活已删除会话）；
+        会先等待在途使用者结束再停止运行时。停止失败时异常向上传播，由调用方决定后续处理。
         外部不应直接操作 ``heartflow_chat_list``，否则会遗留运行中的后台任务和簿记数据。
         """
         async with self._borrow_create_lock(session_id):
-            await self._evict_chat(session_id, reason=reason)
+            await self._evict_chat_locked(session_id, reason=reason)
 
     async def clear_chat_history_context(self, session_id: str) -> bool:
         """停止并移除当前会话运行时，使其短期历史上下文立即失效。
 
         与创建流程共用同一把会话锁，并在锁内检查运行时是否存在：
         避免创建流程持锁停在 ``await new_chat.start()`` 时，此处锁外检查误判为不存在，
-        随后创建流程又把运行时写回列表的竞态。
+        随后创建流程又把运行时写回列表的竞态。停止失败时异常向上传播。
         """
         async with self._borrow_create_lock(session_id):
             if session_id not in self.heartflow_chat_list:
                 return False
-            await self._evict_chat(session_id, reason="clear_context_command")
+            await self._evict_chat_locked(session_id, reason="clear_context_command")
             return True
 
     def adjust_talk_frequency(self, session_id: str, frequency: float) -> None:

--- a/src/chat/heart_flow/heartflow_manager.py
+++ b/src/chat/heart_flow/heartflow_manager.py
@@ -61,9 +61,10 @@ class HeartflowManager:
         async with self._borrow_create_lock(session_id):
             chat = await self._get_or_create_locked(session_id)
             self._acquire_chat_usage(session_id)
-        # 锁外触发上限淘汰：淘汰需要逐个获取其他会话的创建锁，避免死锁
-        await self._evict_over_limit_chats(protected_session_id=session_id)
         try:
+            # 锁外触发上限淘汰：淘汰需要逐个获取其他会话的创建锁，避免死锁；
+            # 与 yield 同处一个 try/finally，保证调用方在此期间被取消时租约仍被释放
+            await self._evict_over_limit_chats(protected_session_id=session_id)
             yield chat
         finally:
             self.release_chat_usage(session_id)

--- a/src/chat/heart_flow/heartflow_message_processor.py
+++ b/src/chat/heart_flow/heartflow_message_processor.py
@@ -51,14 +51,24 @@ class HeartFCMessageReceiver:
             # message.is_mentioned = is_mentioned
             # message.is_at = is_at
 
-            # 以使用租约借用运行时：租约覆盖消息入库与注册全程，
-            # 避免期间运行时被释放/淘汰后仍被写入缓存与状态
+            # 先完成消息入库持久化，确保即便心流运行时借用失败，消息数据也不会丢失。
+            try:
+                await MessageUtils.store_message_to_db_async(message)
+            except Exception as e:
+                logger.error(
+                    f"消息入库失败: session_id={message.session_id}, msg_id={message.message_id}, error={e}",
+                    exc_info=True,
+                )
+
+            # 以使用租约借用运行时完成心流注册，避免处理期间运行时被淘汰。
             try:
                 async with heartflow_manager.borrow_chat(message.session_id) as chat:
-                    await MessageUtils.store_message_to_db_async(message)  # 存储消息到数据库
                     await chat.register_message(message)
             except Exception as e:
-                logger.error(f"出现错误: {e}")
+                logger.error(
+                    f"心流消息注册失败: session_id={message.session_id}, msg_id={message.message_id}, error={e}",
+                    exc_info=True,
+                )
 
             # 3. 日志记录
             mes_name = group_info.group_name if group_info else "私聊"

--- a/src/chat/heart_flow/heartflow_message_processor.py
+++ b/src/chat/heart_flow/heartflow_message_processor.py
@@ -51,15 +51,14 @@ class HeartFCMessageReceiver:
             # message.is_mentioned = is_mentioned
             # message.is_at = is_at
 
-            chat = None
+            # 以使用租约借用运行时：租约覆盖消息入库与注册全程，
+            # 避免期间运行时被释放/淘汰后仍被写入缓存与状态
             try:
-                chat = await heartflow_manager.get_or_create_heartflow_chat(message.session_id)
+                async with heartflow_manager.borrow_chat(message.session_id) as chat:
+                    await MessageUtils.store_message_to_db_async(message)  # 存储消息到数据库
+                    await chat.register_message(message)
             except Exception as e:
                 logger.error(f"出现错误: {e}")
-
-            await MessageUtils.store_message_to_db_async(message)  # 存储消息到数据库
-            if chat is not None:
-                await chat.register_message(message)
 
             # 3. 日志记录
             mes_name = group_info.group_name if group_info else "私聊"

--- a/src/chat/message_receive/chat_manager.py
+++ b/src/chat/message_receive/chat_manager.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import asyncio
@@ -20,6 +20,12 @@ if TYPE_CHECKING:
 install(extra_lines=3)
 
 logger = get_logger("chat_manager")
+
+# 会话内存缓存的淘汰阈值：超过该时长没有任何消息的会话从内存中移除。
+# 数据库记录保留，后续消息到达时会通过 get_or_create_session 自动重新加载，
+# 避免长期运行时内存随历史会话数无界增长。与 heartflow 的 24 小时不活跃
+# 淘汰阈值保持一致，尽量保证被淘汰时没有仍在使用的运行时引用。
+SESSION_EVICTION_INACTIVE_SECONDS = 24 * 60 * 60
 
 
 class SessionContext:
@@ -262,6 +268,49 @@ class ChatManager:
                 await asyncio.to_thread(self.save_all_sessions)
             except Exception as e:
                 logger.error(f"定期保存会话记录时发生错误: {e}")
+            # 保存成功后再淘汰不活跃会话，确保被淘汰的会话数据已落库。
+            try:
+                evicted_count = await asyncio.to_thread(self.evict_inactive_sessions)
+                if evicted_count:
+                    logger.info(f"已从内存淘汰 {evicted_count} 个不活跃会话（数据保留在数据库中）")
+            except Exception as e:
+                logger.error(f"淘汰不活跃会话时发生错误: {e}")
+
+    def evict_inactive_sessions(
+        self,
+        inactive_seconds: float = SESSION_EVICTION_INACTIVE_SECONDS,
+    ) -> int:
+        """将长时间不活跃的会话与其最近一条消息从内存缓存中移除。
+
+        只影响内存缓存：数据库中的会话记录保留，后续消息到达时
+        会通过 get_or_create_session 自动重新加载。
+
+        Args:
+            inactive_seconds: 不活跃阈值，单位为秒，默认为24小时
+        Returns:
+            int: 淘汰的会话数量
+        """
+        stale_cutoff = datetime.now() - timedelta(seconds=inactive_seconds)
+
+        stale_session_ids = [
+            session_id
+            for session_id, session in self.sessions.items()
+            # last_active_timestamp 缺失时回退到会话创建时间。
+            if (session.last_active_timestamp or session.created_timestamp) < stale_cutoff
+        ]
+        for session_id in stale_session_ids:
+            self.sessions.pop(session_id, None)
+
+        # last_messages 可能包含尚未创建会话对象的条目，按消息自身时间戳判断。
+        stale_message_ids = [
+            session_id
+            for session_id, message in self.last_messages.items()
+            if isinstance(message.timestamp, datetime) and message.timestamp < stale_cutoff
+        ]
+        for session_id in stale_message_ids:
+            self.last_messages.pop(session_id, None)
+
+        return len(stale_session_ids)
 
     def save_all_sessions(self):
         """将内存中的全部会话记录保存到数据库"""

--- a/src/chat/message_receive/chat_manager.py
+++ b/src/chat/message_receive/chat_manager.py
@@ -198,6 +198,11 @@ class ChatManager:
         if session is not None and self._update_session_identity(session, message):
             self._save_session(session)
 
+    def release_session(self, session_id: str) -> None:
+        """释放指定聊天流的内存缓存（会话对象与最近一条消息），供聊天流删除等场景调用。"""
+        self.sessions.pop(session_id, None)
+        self.last_messages.pop(session_id, None)
+
     @staticmethod
     def _normalize_identity_text(value: Optional[str]) -> Optional[str]:
         normalized_value = str(value or "").strip()

--- a/src/chat/message_receive/chat_manager.py
+++ b/src/chat/message_receive/chat_manager.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import asyncio
+import threading
 
 from rich.traceback import install
 from sqlmodel import select
@@ -91,6 +92,8 @@ class ChatManager:
     def __init__(self) -> None:
         self.sessions: Dict[str, BotChatSession] = {}  # session_id -> BotChatSession
         self.last_messages: Dict[str, "SessionMessage"] = {}  # session_id -> SessionMessage
+        self._deleted_session_ids: Set[str] = set()
+        self._session_lock = threading.Lock()
 
     async def initialize(self):
         """初始化聊天管理器"""
@@ -128,6 +131,8 @@ class ChatManager:
             account_id=account_id,
             scope=scope,
         )
+        with self._session_lock:
+            self._deleted_session_ids.discard(session_id)
         if session := self.get_session_by_session_id(session_id):
             route_metadata_changed = self._apply_route_metadata(session, account_id=account_id, scope=scope)
             session.update_active_time()
@@ -206,8 +211,10 @@ class ChatManager:
 
     def release_session(self, session_id: str) -> None:
         """释放指定聊天流的内存缓存（会话对象与最近一条消息），供聊天流删除等场景调用。"""
-        self.sessions.pop(session_id, None)
-        self.last_messages.pop(session_id, None)
+        with self._session_lock:
+            self._deleted_session_ids.add(session_id)
+            self.sessions.pop(session_id, None)
+            self.last_messages.pop(session_id, None)
 
     @staticmethod
     def _normalize_identity_text(value: Optional[str]) -> Optional[str]:
@@ -266,15 +273,12 @@ class ChatManager:
             await asyncio.sleep(interval_seconds)
             try:
                 await asyncio.to_thread(self.save_all_sessions)
-            except Exception as e:
-                logger.error(f"定期保存会话记录时发生错误: {e}")
-            # 保存成功后再淘汰不活跃会话，确保被淘汰的会话数据已落库。
-            try:
+                # 仅在保存成功后才淘汰不活跃会话，确保被淘汰的会话数据已落库。
                 evicted_count = await asyncio.to_thread(self.evict_inactive_sessions)
                 if evicted_count:
                     logger.info(f"已从内存淘汰 {evicted_count} 个不活跃会话（数据保留在数据库中）")
             except Exception as e:
-                logger.error(f"淘汰不活跃会话时发生错误: {e}")
+                logger.error(f"定期保存/淘汰会话记录时发生错误: {e}")
 
     def evict_inactive_sessions(
         self,
@@ -292,32 +296,39 @@ class ChatManager:
         """
         stale_cutoff = datetime.now() - timedelta(seconds=inactive_seconds)
 
-        stale_session_ids = [
-            session_id
-            for session_id, session in self.sessions.items()
-            # last_active_timestamp 缺失时回退到会话创建时间。
-            if (session.last_active_timestamp or session.created_timestamp) < stale_cutoff
-        ]
-        for session_id in stale_session_ids:
-            self.sessions.pop(session_id, None)
+        with self._session_lock:
+            stale_session_ids = [
+                session_id
+                for session_id, session in list(self.sessions.items())
+                # last_active_timestamp 缺失时回退到会话创建时间。
+                if (session.last_active_timestamp or session.created_timestamp) < stale_cutoff
+            ]
+            for session_id in stale_session_ids:
+                self.sessions.pop(session_id, None)
 
-        # last_messages 可能包含尚未创建会话对象的条目，按消息自身时间戳判断。
-        stale_message_ids = [
-            session_id
-            for session_id, message in self.last_messages.items()
-            if isinstance(message.timestamp, datetime) and message.timestamp < stale_cutoff
-        ]
-        for session_id in stale_message_ids:
-            self.last_messages.pop(session_id, None)
+            # last_messages 可能包含尚未创建会话对象的条目，按消息自身时间戳判断。
+            stale_message_ids = [
+                session_id
+                for session_id, message in list(self.last_messages.items())
+                if isinstance(message.timestamp, datetime) and message.timestamp < stale_cutoff
+            ]
+            for session_id in stale_message_ids:
+                self.last_messages.pop(session_id, None)
 
         return len(stale_session_ids)
 
     def save_all_sessions(self):
         """将内存中的全部会话记录保存到数据库"""
         try:
-            for session in self.sessions.values():
+            with self._session_lock:
+                sessions_to_save = [
+                    session
+                    for session in list(self.sessions.values())
+                    if session.session_id not in self._deleted_session_ids
+                ]
+            for session in sessions_to_save:
                 self._save_session(session)
-            logger.info(f"共 {len(self.sessions)} 个会话已经保存到数据库中")
+            logger.info(f"共 {len(sessions_to_save)} 个会话已经保存到数据库中")
         except Exception as e:
             logger.error(f"保存会话记录到数据库时发生错误: {e}")
             raise e
@@ -575,6 +586,9 @@ class ChatManager:
 
     def _save_session(self, session: BotChatSession):
         """将会话记录保存到数据库"""
+        with self._session_lock:
+            if session.session_id in self._deleted_session_ids:
+                return
         with get_db_session() as db_session:
             db_instance = session.to_db_instance()
             statement = select(ChatSession).filter_by(session_id=db_instance.session_id).limit(1)

--- a/src/chat/replyer/replyer_manager.py
+++ b/src/chat/replyer/replyer_manager.py
@@ -65,5 +65,19 @@ class ReplyerManager:
         logger.debug(f"Replyer 创建完成: cache_key={cache_key}")
         return replyer
 
+    def invalidate_replyer(self, stream_id: str) -> None:
+        """使指定会话的所有 replyer 缓存失效，供聊天流删除等场景调用。"""
+        normalized_stream_id = str(stream_id or "").strip()
+        if not normalized_stream_id:
+            logger.warning("[ReplyerManager] 缺少 stream_id，跳过 replyer 缓存失效")
+            return
+
+        suffix = f":{normalized_stream_id}"
+        stale_keys = [cache_key for cache_key in self._repliers if cache_key.endswith(suffix)]
+        for cache_key in stale_keys:
+            self._repliers.pop(cache_key, None)
+        if stale_keys:
+            logger.info(f"[ReplyerManager] 已失效 {len(stale_keys)} 个 replyer 缓存: stream_id={normalized_stream_id}")
+
 
 replyer_manager = ReplyerManager()

--- a/src/chat/utils/statistic.py
+++ b/src/chat/utils/statistic.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from html import escape
 from os import getenv
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, Coroutine, cast
 
 import asyncio
 import concurrent.futures
@@ -26,6 +26,19 @@ logger = get_logger("maibot_statistic")
 
 STATISTICS_REPORT_PATH_ENV = "MAIBOT_STATISTICS_REPORT_PATH"
 DEFAULT_STATISTICS_REPORT_PATH = "maibot_statistics.html"
+
+# 后台任务强引用集合：asyncio 对 task 仅持有弱引用，创建后不保存引用的
+# 任务可能在执行中被垃圾回收；任务完成后通过回调自动移除。
+_background_tasks: set["asyncio.Task[None]"] = set()
+
+
+def _create_tracked_task(coro: "Coroutine[Any, Any, None]") -> "asyncio.Task[None]":
+    """创建带强引用的后台任务，防止统计任务执行中途被 GC 静默回收。"""
+
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
 
 
 class _LocalStorageProxy:
@@ -564,8 +577,8 @@ class StatisticOutputTask(AsyncTask):
             except Exception as e:
                 logger.exception(f"后台统计数据输出过程中发生异常：{e}")
 
-        # 创建后台任务，立即返回
-        asyncio.create_task(_async_collect_and_output())
+        # 创建后台任务，立即返回（保留强引用防止任务被 GC 中途回收）
+        _create_tracked_task(_async_collect_and_output())
 
     # -- 以下为统计数据收集方法 --
 
@@ -3188,5 +3201,5 @@ class AsyncStatisticOutputTask(AsyncTask):
             except Exception as e:
                 logger.exception(f"后台统计数据输出过程中发生异常：{e}")
 
-        # 创建后台任务，立即返回
-        asyncio.create_task(_async_collect_and_output())
+        # 创建后台任务，立即返回（保留强引用防止任务被 GC 中途回收）
+        _create_tracked_task(_async_collect_and_output())

--- a/src/chat/utils/utils.py
+++ b/src/chat/utils/utils.py
@@ -917,6 +917,32 @@ def get_chat_type_and_target_info(chat_id: str) -> Tuple[bool, Optional["ChatTar
     return is_group_chat, chat_target_info
 
 
+# replyer 动作临时文件的保留数量上限：这些文件只用于临时排查，
+# 每次群聊回复都会新增一个，不清理会随运行时长无限累积。
+MAX_REPLYER_ACTION_TEMP_FILES = 200
+
+
+def _cleanup_replyer_action_temp_files(temp_dir: str) -> None:
+    """把 replyer 动作临时文件裁剪到保留数量上限内（删除最旧的）。"""
+
+    try:
+        entries = [
+            entry
+            for entry in os.listdir(temp_dir)
+            if entry.startswith("replyer_action_") and entry.endswith(".json")
+        ]
+        if len(entries) <= MAX_REPLYER_ACTION_TEMP_FILES:
+            return
+        entries.sort()
+        for filename in entries[: len(entries) - MAX_REPLYER_ACTION_TEMP_FILES]:
+            try:
+                os.remove(os.path.join(temp_dir, filename))
+            except OSError:
+                continue
+    except Exception as e:
+        logger.debug(f"清理replyer动作临时文件失败: {e}")
+
+
 def record_replyer_action_temp(chat_id: str, reason: str, think_level: int) -> None:
     """
     临时记录replyer动作被选择的信息（仅群聊）
@@ -947,6 +973,9 @@ def record_replyer_action_temp(chat_id: str, reason: str, think_level: int) -> N
         # 写入文件
         with open(filepath, "w", encoding="utf-8") as f:
             json.dump(record_data, f, ensure_ascii=False, indent=2)
+
+        # 文件名含微秒级时间戳，按名称排序即按创建顺序排序，裁掉最旧的。
+        _cleanup_replyer_action_temp_files(temp_dir)
 
         logger.debug(f"已记录replyer动作选择: chat_id={chat_id}, think_level={think_level}")
     except Exception as e:

--- a/src/cli/bot_console.py
+++ b/src/cli/bot_console.py
@@ -274,4 +274,8 @@ class BotConsole:
         finally:
             await self._unregister_output_driver()
             if self._session_id is not None:
-                await heartflow_manager.release_chat(self._session_id, reason="cli_exit")
+                try:
+                    await heartflow_manager.release_chat(self._session_id, reason="cli_exit")
+                except Exception as exc:
+                    # 退出清理为尽力而为：停止失败不应中断退出流程
+                    console.print(f"[bold red]释放心流运行时失败: {exc}[/bold red]")

--- a/src/cli/bot_console.py
+++ b/src/cli/bot_console.py
@@ -274,6 +274,4 @@ class BotConsole:
         finally:
             await self._unregister_output_driver()
             if self._session_id is not None:
-                runtime = heartflow_manager.heartflow_chat_list.pop(self._session_id, None)
-                if runtime is not None:
-                    await runtime.stop()
+                await heartflow_manager.release_chat(self._session_id, reason="cli_exit")

--- a/src/cli/maisaka_cli.py
+++ b/src/cli/maisaka_cli.py
@@ -114,6 +114,4 @@ class BufferCLI:
                 await self._dispatch_input(user_text)
         finally:
             if self._session is not None:
-                runtime = heartflow_manager.heartflow_chat_list.pop(self._session.session_id, None)
-                if runtime is not None:
-                    await runtime.stop()
+                await heartflow_manager.release_chat(self._session.session_id, reason="cli_exit")

--- a/src/cli/maisaka_cli.py
+++ b/src/cli/maisaka_cli.py
@@ -114,4 +114,8 @@ class BufferCLI:
                 await self._dispatch_input(user_text)
         finally:
             if self._session is not None:
-                await heartflow_manager.release_chat(self._session.session_id, reason="cli_exit")
+                try:
+                    await heartflow_manager.release_chat(self._session.session_id, reason="cli_exit")
+                except Exception as exc:
+                    # 退出清理为尽力而为：停止失败不应中断退出流程
+                    console.print(f"[bold red]释放心流运行时失败: {exc}[/bold red]")

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -234,6 +234,12 @@ class WebSocketLogHandler(logging.Handler):
 
         try:
             from src.webui.logs_ws import broadcast_log
+            from src.webui.routers.websocket.manager import websocket_manager
+
+            # 无订阅者时直接跳过：日志是全仓库频率最高的事件源，
+            # 每行日志创建一个广播任务会在无前端连接时白白消耗事件循环。
+            if not websocket_manager.has_topic_subscribers("logs", "main"):
+                return
 
             broadcast_coro = broadcast_log(log_data)
             try:

--- a/src/core/announcement_manager.py
+++ b/src/core/announcement_manager.py
@@ -31,6 +31,9 @@ class GlobalAnnouncementManager:
         if chat_id in self._user_disabled_actions:
             try:
                 self._user_disabled_actions[chat_id].remove(action_name)
+                # 列表清空后删除键，避免空条目随聊天数无界积累。
+                if not self._user_disabled_actions[chat_id]:
+                    del self._user_disabled_actions[chat_id]
                 return True
             except ValueError:
                 logger.warning(f"动作 {action_name} 不在禁用列表中")
@@ -52,6 +55,8 @@ class GlobalAnnouncementManager:
         if chat_id in self._user_disabled_commands:
             try:
                 self._user_disabled_commands[chat_id].remove(command_name)
+                if not self._user_disabled_commands[chat_id]:
+                    del self._user_disabled_commands[chat_id]
                 return True
             except ValueError:
                 logger.warning(f"命令 {command_name} 不在禁用列表中")
@@ -73,6 +78,8 @@ class GlobalAnnouncementManager:
         if chat_id in self._user_disabled_event_handlers:
             try:
                 self._user_disabled_event_handlers[chat_id].remove(handler_name)
+                if not self._user_disabled_event_handlers[chat_id]:
+                    del self._user_disabled_event_handlers[chat_id]
                 return True
             except ValueError:
                 logger.warning(f"事件处理器 {handler_name} 不在禁用列表中")
@@ -94,6 +101,8 @@ class GlobalAnnouncementManager:
         if chat_id in self._user_disabled_tools:
             try:
                 self._user_disabled_tools[chat_id].remove(tool_name)
+                if not self._user_disabled_tools[chat_id]:
+                    del self._user_disabled_tools[chat_id]
                 return True
             except ValueError:
                 logger.warning(f"工具 {tool_name} 不在禁用列表中")

--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -59,20 +59,24 @@ class EventBus:
         if event_type not in self._handlers:
             self._handlers[event_type] = []
 
+        # 同名重复注册会导致 emit 时同一 handler 被执行多次，直接暴露错误。
+        if any(existing.name == name for existing in self._handlers[event_type]):
+            raise ValueError(f"事件 handler 重复注册: {name} -> {event_type}")
+
         entry = _HandlerEntry(handler=handler, name=name, weight=weight, intercept=intercept)
         self._handlers[event_type].append(entry)
         self._handlers[event_type].sort(key=lambda e: e.weight, reverse=True)
         logger.debug(f"注册事件 handler: {name} -> {event_type} (weight={weight}, intercept={intercept})")
 
     def unsubscribe(self, event_type: EventType | str, name: str) -> bool:
-        """取消注册事件 handler"""
+        """取消注册事件 handler（同名条目全部移除）"""
         handlers = self._handlers.get(event_type, [])
-        for i, entry in enumerate(handlers):
-            if entry.name == name:
-                del handlers[i]
-                logger.debug(f"取消注册事件 handler: {name} <- {event_type}")
-                return True
-        return False
+        remaining = [entry for entry in handlers if entry.name != name]
+        if len(remaining) == len(handlers):
+            return False
+        self._handlers[event_type] = remaining
+        logger.debug(f"取消注册事件 handler: {name} <- {event_type}")
+        return True
 
     async def emit(
         self,

--- a/src/emoji_system/emoji_manager.py
+++ b/src/emoji_system/emoji_manager.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Optional
+from weakref import WeakValueDictionary
 
 import asyncio
 import hashlib
@@ -275,7 +276,8 @@ class EmojiManager:
         self.emojis: list[MaiEmoji] = []
         self._maintenance_wakeup_event: asyncio.Event = asyncio.Event()
         self._pending_description_tasks: dict[str, asyncio.Task[None]] = {}
-        self._emoji_save_locks: dict[str, asyncio.Lock] = {}
+        # 弱值字典保存按哈希的写入锁：等待中的协程持有强引用，用完即被自动回收，避免按表情哈希无限累积。
+        self._emoji_save_locks: WeakValueDictionary = WeakValueDictionary()
         self._reload_callback_registered: bool = False
 
         config_manager.register_reload_callback(self.reload_runtime_config)
@@ -383,7 +385,10 @@ class EmojiManager:
 
         hash_str = emoji_hash or hashlib.sha256(emoji_bytes).hexdigest()
 
-        save_lock = self._emoji_save_locks.setdefault(hash_str, asyncio.Lock())
+        save_lock = self._emoji_save_locks.get(hash_str)
+        if save_lock is None:
+            save_lock = asyncio.Lock()
+            self._emoji_save_locks[hash_str] = save_lock
         async with save_lock:
             return await self._ensure_emoji_saved_locked(emoji_bytes, hash_str)
 

--- a/src/emoji_system/emoji_manager.py
+++ b/src/emoji_system/emoji_manager.py
@@ -524,17 +524,13 @@ class EmojiManager:
         logger.debug("[数据库] 开始加载所有表情包记录...")
         try:
             with get_db_session() as session:
-                statement = select(Images)
+                # 在 SQL 层完成过滤：Images 表同时存放聊天图片等记录，
+                # 无过滤的全表物化会随聊天图片数量增长造成启动内存尖峰。
+                statement = select(Images).filter_by(image_type=ImageType.EMOJI, is_registered=True, is_banned=False)
                 results = session.exec(statement).all()
                 self.emojis = []
                 removed_record_count = 0
                 for record in results:
-                    if record.image_type != ImageType.EMOJI:
-                        continue
-                    if not record.is_registered:
-                        continue
-                    if record.is_banned:
-                        continue
                     try:
                         if record.no_file_flag or _resolve_existing_emoji_path(record.full_path) is None:
                             logger.warning(
@@ -563,6 +559,16 @@ class EmojiManager:
             self.emojis = []
             self._emoji_num = 0
             raise e
+
+    @staticmethod
+    def _release_emoji_image_bytes(emoji: MaiEmoji) -> None:
+        """注册完成后释放内存中的图片字节。
+
+        表情文件已持久化到磁盘与数据库，后续使用（如转 base64）会按需从磁盘回读
+        （见 get_emoji_base64_information 等处的 image_bytes or 回读逻辑）；
+        长期驻留 bytes 会让整个表情集合常驻占用数十 MB 内存。
+        """
+        emoji.image_bytes = None
 
     def register_emoji_to_db(self, emoji: MaiEmoji) -> EmojiRegisterStatus:
         # sourcery skip: extract-method
@@ -936,6 +942,7 @@ class EmojiManager:
                     register_status = self.register_emoji_to_db(new_emoji)
                     if register_status == "registered":
                         self.emojis.append(new_emoji)
+                        self._release_emoji_image_bytes(new_emoji)
                         self._emoji_num = len(self.emojis)
                         logger.info(f"[register_emoji] 成功替换并注册新表情包: {new_emoji.description}")
                         return True
@@ -1282,6 +1289,7 @@ class EmojiManager:
         register_status = self.register_emoji_to_db(target_emoji)
         if register_status == "registered":
             self.emojis.append(target_emoji)
+            self._release_emoji_image_bytes(target_emoji)
             self._emoji_num = len(self.emojis)
             logger.info(f"[register_emoji] Registered new emoji: {target_emoji.file_name}")
         elif register_status == "failed":

--- a/src/learners/behavior_pattern_maintenance.py
+++ b/src/learners/behavior_pattern_maintenance.py
@@ -75,8 +75,24 @@ class BehaviorPatternMaintenanceService:
             session_id=normalized_session_id,
             related_session_ids=related_session_ids,
         )
-        self._last_run_at_by_session_id[normalized_session_id] = current_time
+        self._record_run_at(normalized_session_id, current_time)
         return result
+
+    def _record_run_at(self, session_id: str, run_at: float) -> None:
+        """记录会话的最近维护时间，并清理冷却窗口外的过期记录。
+
+        冷却窗口外的记录与缺失等价（都会允许再次维护），
+        及时清理可避免字典随历史会话数无界增长。
+        """
+
+        self._last_run_at_by_session_id[session_id] = run_at
+        stale_ids = [
+            recorded_session_id
+            for recorded_session_id, recorded_at in self._last_run_at_by_session_id.items()
+            if run_at - recorded_at >= MAINTENANCE_COOLDOWN_SECONDS
+        ]
+        for stale_id in stale_ids:
+            self._last_run_at_by_session_id.pop(stale_id, None)
 
     def maintain_session(
         self,

--- a/src/learners/jargon_miner.py
+++ b/src/learners/jargon_miner.py
@@ -143,6 +143,8 @@ class JargonMiner:
         self.cache: OrderedDict[str, None] = OrderedDict()
         # 黑话提取锁，防止并发执行
         self._extraction_lock = asyncio.Lock()
+        # 进行中的含义推断任务（按 jargon id 去重），防止同一词条并发重复推断
+        self._inflight_inference_tasks: Dict[int, "asyncio.Task[None]"] = {}
 
     @staticmethod
     def _get_runtime_manager() -> Any:
@@ -692,7 +694,12 @@ class JargonMiner:
                 # 已存在记录，更新 count 和证据消息引用
                 self._update_jargon(matched_jargon, evidence_messages)
                 if self._should_infer_meaning(matched_jargon):
-                    asyncio.create_task(self._infer_meaning_by_id(matched_jargon.id))  # type: ignore
+                    jargon_id = int(matched_jargon.id)  # type: ignore
+                    if jargon_id not in self._inflight_inference_tasks:
+                        self._inflight_inference_tasks[jargon_id] = asyncio.create_task(
+                            self._infer_meaning_by_id(jargon_id)
+                        )
+                        self._inflight_inference_tasks[jargon_id].add_done_callback(self._on_inference_done)
                 updated += 1
             else:
                 # 没找到匹配记录，创建新记录
@@ -876,6 +883,20 @@ class JargonMiner:
         )
         # 如果没有找到下一个阈值，说明已经超过100，不应该再推断
         return False if next_threshold is None else count >= next_threshold
+
+    def _on_inference_done(self, task: "asyncio.Task[None]") -> None:
+        """推断任务结束后清理进行中去重集合，并记录未捕获异常。"""
+
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(f"黑话含义推断任务发生异常: {e}")
+        finally:
+            for jargon_id, running_task in list(self._inflight_inference_tasks.items()):
+                if running_task is task:
+                    del self._inflight_inference_tasks[jargon_id]
 
     async def _infer_meaning_by_id(self, jargon_id: int):
         jargon_obj: Optional[MaiJargon] = None

--- a/src/llm_models/model_client/base_client.py
+++ b/src/llm_models/model_client/base_client.py
@@ -328,13 +328,27 @@ class BaseClient(ABC):
             api_provider: API 提供商配置。
         """
         self.api_provider = api_provider
+        self._active_request_leases = 0
+        """正在使用本实例的进行中请求数；淘汰时需等待归零后再关闭连接池。"""
+        self._dispose_pending = False
+        """实例已被注册表淘汰，待活跃请求归零后关闭连接池。"""
+        self._closed = False
+        """底层连接池是否已关闭，保证 aclose 幂等。"""
 
     async def aclose(self) -> None:
         """释放客户端持有的底层 HTTP 连接池，供实例被淘汰时调用。
 
         底层 SDK 客户端类型多样（AsyncOpenAI、genai.Client、httpx.AsyncClient 等），
         统一按 ``aclose``/``close`` 协议探测并兼容同步/异步关闭方法。
+        本方法幂等：重复调用不会重复关闭底层资源。
+
+        注意：调用方应通过请求租约（``acquire_request_lease``/``release_request_lease``）
+        确保没有进行中的请求正在使用本实例，避免关闭连接池打断在途请求。
         """
+        if self._closed:
+            return
+        # 先同步置位再执行异步关闭，保证并发调用方只会真正关闭一次
+        self._closed = True
         inner_client = getattr(self, "client", None)
         closer = getattr(inner_client, "aclose", None)
         if not callable(closer):
@@ -344,6 +358,29 @@ class BaseClient(ABC):
         result = closer()
         if inspect.isawaitable(result):
             await result
+
+    def acquire_request_lease(self) -> None:
+        """登记一次进行中的请求，使淘汰流程推迟到该请求结束后再关闭连接池。"""
+        self._active_request_leases += 1
+
+    def release_request_lease(self) -> None:
+        """注销一次已结束的请求租约。"""
+        if self._active_request_leases > 0:
+            self._active_request_leases -= 1
+
+    def mark_dispose_pending(self) -> bool:
+        """标记实例已被注册表淘汰，等待关闭连接池。
+
+        Returns:
+            bool: True 表示当前无活跃请求，可立即调度关闭；
+                  False 表示仍有请求在使用本实例，由最后一个结束的请求负责关闭。
+        """
+        self._dispose_pending = True
+        return self._active_request_leases == 0
+
+    def should_close_after_release(self) -> bool:
+        """请求结束后判断是否应由当前调用方关闭连接池（实例已被淘汰且活跃请求归零）。"""
+        return self._dispose_pending and not self._closed and self._active_request_leases == 0
 
     @abstractmethod
     async def get_response(self, request: ResponseRequest) -> APIResponse:
@@ -431,6 +468,8 @@ class ClientRegistry:
         """插件 ID -> 该插件拥有的 client_type 集合。"""
         self._dispose_tasks: Set["asyncio.Task[None]"] = set()
         """待完成的旧客户端连接池释放任务，持有强引用防止被事件循环回收。"""
+        self._pending_dispose_clients: List[BaseClient] = []
+        """因暂无可用事件循环而挂起的被淘汰客户端，待下次进入事件循环时补齐释放。"""
         config_manager.register_reload_callback(self.clear_client_instance_cache)
 
     def register_client_class(self, client_type: str) -> Callable[[Type[BaseClient]], Type[BaseClient]]:
@@ -596,21 +635,90 @@ class ClientRegistry:
             removed_count += 1
         return removed_count
 
+    @staticmethod
+    def _get_running_loop() -> "asyncio.AbstractEventLoop | None":
+        """返回当前运行中的事件循环；不在事件循环内时返回 None。"""
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
     def _on_dispose_done(self, task: "asyncio.Task[None]") -> None:
         """回收已完成的释放任务并记录异常。"""
         self._dispose_tasks.discard(task)
         if not task.cancelled() and task.exception() is not None:
             logger.warning(f"释放旧 LLM 客户端连接池失败: {task.exception()}")
 
-    def _schedule_dispose(self, stale_clients: List[BaseClient]) -> None:
-        """在当前事件循环上调度释放被淘汰的客户端实例，避免其 HTTP 连接池残留。"""
-        if not stale_clients:
+    def _start_dispose_task(self, loop: asyncio.AbstractEventLoop, stale_client: BaseClient) -> None:
+        """在指定事件循环上创建并跟踪一个旧客户端释放任务。"""
+        task = loop.create_task(stale_client.aclose())
+        self._dispose_tasks.add(task)
+        task.add_done_callback(self._on_dispose_done)
+
+    def _flush_pending_dispose(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """补齐释放此前因缺少可用事件循环而挂起的被淘汰客户端。"""
+        if loop is None or not self._pending_dispose_clients:
             return
-        loop = asyncio.get_running_loop()
-        for stale_client in stale_clients:
-            task = loop.create_task(stale_client.aclose())
-            self._dispose_tasks.add(task)
-            task.add_done_callback(self._on_dispose_done)
+        pending_clients = self._pending_dispose_clients
+        self._pending_dispose_clients = []
+        for stale_client in pending_clients:
+            self._start_dispose_task(loop, stale_client)
+        logger.info(f"已在当前事件循环上补齐 {len(pending_clients)} 个此前挂起的旧 LLM 客户端释放任务")
+
+    def _dispose_when_possible(
+        self,
+        stale_client: BaseClient,
+        owner_loop: asyncio.AbstractEventLoop | None,
+        current_loop: asyncio.AbstractEventLoop | None,
+    ) -> None:
+        """为单个无活跃请求的被淘汰客户端选择合适的事件循环并调度关闭。
+
+        Args:
+            stale_client: 已无活跃请求的被淘汰客户端。
+            owner_loop: 其缓存键绑定的事件循环，可能为 None（创建时无运行中循环）。
+            current_loop: 当前运行中的事件循环，可能为 None。
+        """
+        target_loop = owner_loop if owner_loop is not None else current_loop
+        if target_loop is None:
+            # 创建与清理都发生在没有事件循环的上下文：挂起，待下次有运行中的循环时补齐释放
+            self._pending_dispose_clients.append(stale_client)
+            logger.debug("暂无可用于释放 LLM 客户端的事件循环，已挂起待下次进入事件循环时处理")
+            return
+        if target_loop is current_loop:
+            self._start_dispose_task(target_loop, stale_client)
+            return
+        # 客户端绑定在其他线程的事件循环上，跨线程安全投递释放任务
+        try:
+            target_loop.call_soon_threadsafe(self._start_dispose_task, target_loop, stale_client)
+        except RuntimeError:
+            # 目标循环已终止，其上的连接资源已随之结束，无法也无需再调度异步关闭
+            logger.warning("LLM 客户端所属事件循环已关闭，跳过其连接池释放")
+
+    def _schedule_dispose(
+        self,
+        stale_entries: List[Tuple[BaseClient, "asyncio.AbstractEventLoop | None"]],
+    ) -> None:
+        """调度释放被淘汰的客户端实例，避免其 HTTP 连接池残留。
+
+        Args:
+            stale_entries: (被淘汰客户端, 其缓存键绑定的事件循环) 列表。
+
+        关闭策略：
+        - 关闭任务优先投递回客户端缓存键绑定的事件循环（可能属于其他线程）。
+        - 仍有进行中请求的实例推迟到其最后一个请求结束时由请求方关闭，
+          避免立即 aclose 打断在途请求。
+        - 找不到任何可用事件循环时先挂起，待下次有运行中的事件循环时补齐释放。
+        """
+        if not stale_entries:
+            return
+
+        current_loop = self._get_running_loop()
+        self._flush_pending_dispose(current_loop)
+
+        for stale_client, owner_loop in stale_entries:
+            if not stale_client.mark_dispose_pending():
+                continue
+            self._dispose_when_possible(stale_client, owner_loop, current_loop)
 
     def clear_client_instance_cache_by_client_type(self, client_type: str) -> None:
         """清理指定客户端类型对应的客户端实例缓存。
@@ -627,21 +735,18 @@ class ClientRegistry:
             for cache_key, client in self.client_instance_cache.items()
             if client.api_provider.client_type == normalized_client_type
         ]
-        stale_clients: List[BaseClient] = []
+        stale_entries: List[Tuple[BaseClient, "asyncio.AbstractEventLoop | None"]] = []
         for cache_key in stale_cache_keys:
             client = self.client_instance_cache.pop(cache_key, None)
             if client is not None:
-                stale_clients.append(client)
-        self._schedule_dispose(stale_clients)
+                # 缓存键首位即该客户端绑定的事件循环，释放任务应投递回原循环
+                stale_entries.append((client, cache_key[0]))
+        self._schedule_dispose(stale_entries)
 
     @staticmethod
     def _get_client_cache_key(api_provider: APIProvider) -> Tuple[asyncio.AbstractEventLoop | None, str]:
         """生成按事件循环隔离的客户端缓存键。"""
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-        return loop, api_provider.name
+        return ClientRegistry._get_running_loop(), api_provider.name
 
     def get_client_class_instance(self, api_provider: APIProvider, force_new: bool = False) -> BaseClient:
         """获取注册的 API 客户端实例。
@@ -656,6 +761,9 @@ class ClientRegistry:
         from . import ensure_client_type_loaded
 
         ensure_client_type_loaded(api_provider.client_type)
+
+        # 若此前有因缺少事件循环而挂起的旧客户端释放任务，在此补齐
+        self._flush_pending_dispose(self._get_running_loop())
 
         # 如果强制创建新实例，直接创建不使用缓存
         if force_new:
@@ -674,9 +782,12 @@ class ClientRegistry:
 
     def clear_client_instance_cache(self) -> None:
         """清空客户端实例缓存。"""
-        stale_clients = list(self.client_instance_cache.values())
+        stale_entries = [
+            (client, owner_loop)
+            for (owner_loop, _provider_name), client in self.client_instance_cache.items()
+        ]
         self.client_instance_cache.clear()
-        self._schedule_dispose(stale_clients)
+        self._schedule_dispose(stale_entries)
         logger.info("检测到配置重载，已清空LLM客户端实例缓存")
 
 

--- a/src/llm_models/model_client/base_client.py
+++ b/src/llm_models/model_client/base_client.py
@@ -743,6 +743,21 @@ class ClientRegistry:
                 stale_entries.append((client, cache_key[0]))
         self._schedule_dispose(stale_entries)
 
+    def _drop_closed_loop_entries(self) -> None:
+        """清理键中事件循环已关闭的缓存条目，避免条目随短生命周期循环增长。"""
+        closed_keys = [
+            cache_key
+            for cache_key in list(self.client_instance_cache)
+            if cache_key[0] is not None and cache_key[0].is_closed()
+        ]
+        stale_entries: List[Tuple[BaseClient, "asyncio.AbstractEventLoop | None"]] = []
+        for cache_key in closed_keys:
+            client = self.client_instance_cache.pop(cache_key, None)
+            if client is not None:
+                stale_entries.append((client, cache_key[0]))
+        if stale_entries:
+            self._schedule_dispose(stale_entries)
+
     @staticmethod
     def _get_client_cache_key(api_provider: APIProvider) -> Tuple[asyncio.AbstractEventLoop | None, str]:
         """生成按事件循环隔离的客户端缓存键。"""
@@ -761,6 +776,9 @@ class ClientRegistry:
         from . import ensure_client_type_loaded
 
         ensure_client_type_loaded(api_provider.client_type)
+
+        # 清理已关闭循环对应的废弃缓存条目
+        self._drop_closed_loop_entries()
 
         # 若此前有因缺少事件循环而挂起的旧客户端释放任务，在此补齐
         self._flush_pending_dispose(self._get_running_loop())

--- a/src/llm_models/model_client/base_client.py
+++ b/src/llm_models/model_client/base_client.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Coroutine, Dict, List, Set, Tuple, Type
 
 import asyncio
 import dataclasses
+import inspect
 import time
 import uuid
 
@@ -328,6 +329,22 @@ class BaseClient(ABC):
         """
         self.api_provider = api_provider
 
+    async def aclose(self) -> None:
+        """释放客户端持有的底层 HTTP 连接池，供实例被淘汰时调用。
+
+        底层 SDK 客户端类型多样（AsyncOpenAI、genai.Client、httpx.AsyncClient 等），
+        统一按 ``aclose``/``close`` 协议探测并兼容同步/异步关闭方法。
+        """
+        inner_client = getattr(self, "client", None)
+        closer = getattr(inner_client, "aclose", None)
+        if not callable(closer):
+            closer = getattr(inner_client, "close", None)
+        if not callable(closer):
+            return
+        result = closer()
+        if inspect.isawaitable(result):
+            await result
+
     @abstractmethod
     async def get_response(self, request: ResponseRequest) -> APIResponse:
         """获取对话响应。
@@ -412,6 +429,8 @@ class ClientRegistry:
         """(事件循环, APIProvider.name) -> BaseClient 的映射表。"""
         self._owner_client_types: Dict[str, Set[str]] = {}
         """插件 ID -> 该插件拥有的 client_type 集合。"""
+        self._dispose_tasks: Set["asyncio.Task[None]"] = set()
+        """待完成的旧客户端连接池释放任务，持有强引用防止被事件循环回收。"""
         config_manager.register_reload_callback(self.clear_client_instance_cache)
 
     def register_client_class(self, client_type: str) -> Callable[[Type[BaseClient]], Type[BaseClient]]:
@@ -577,6 +596,22 @@ class ClientRegistry:
             removed_count += 1
         return removed_count
 
+    def _on_dispose_done(self, task: "asyncio.Task[None]") -> None:
+        """回收已完成的释放任务并记录异常。"""
+        self._dispose_tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            logger.warning(f"释放旧 LLM 客户端连接池失败: {task.exception()}")
+
+    def _schedule_dispose(self, stale_clients: List[BaseClient]) -> None:
+        """在当前事件循环上调度释放被淘汰的客户端实例，避免其 HTTP 连接池残留。"""
+        if not stale_clients:
+            return
+        loop = asyncio.get_running_loop()
+        for stale_client in stale_clients:
+            task = loop.create_task(stale_client.aclose())
+            self._dispose_tasks.add(task)
+            task.add_done_callback(self._on_dispose_done)
+
     def clear_client_instance_cache_by_client_type(self, client_type: str) -> None:
         """清理指定客户端类型对应的客户端实例缓存。
 
@@ -592,8 +627,12 @@ class ClientRegistry:
             for cache_key, client in self.client_instance_cache.items()
             if client.api_provider.client_type == normalized_client_type
         ]
+        stale_clients: List[BaseClient] = []
         for cache_key in stale_cache_keys:
-            self.client_instance_cache.pop(cache_key, None)
+            client = self.client_instance_cache.pop(cache_key, None)
+            if client is not None:
+                stale_clients.append(client)
+        self._schedule_dispose(stale_clients)
 
     @staticmethod
     def _get_client_cache_key(api_provider: APIProvider) -> Tuple[asyncio.AbstractEventLoop | None, str]:
@@ -635,7 +674,9 @@ class ClientRegistry:
 
     def clear_client_instance_cache(self) -> None:
         """清空客户端实例缓存。"""
+        stale_clients = list(self.client_instance_cache.values())
         self.client_instance_cache.clear()
+        self._schedule_dispose(stale_clients)
         logger.info("检测到配置重载，已清空LLM客户端实例缓存")
 
 

--- a/src/llm_models/model_client/base_client.py
+++ b/src/llm_models/model_client/base_client.py
@@ -678,9 +678,9 @@ class ClientRegistry:
             owner_loop: 其缓存键绑定的事件循环，可能为 None（创建时无运行中循环）。
             current_loop: 当前运行中的事件循环，可能为 None。
         """
-        target_loop = owner_loop if owner_loop is not None else current_loop
-        if target_loop is None:
-            # 创建与清理都发生在没有事件循环的上下文：挂起，待下次有运行中的循环时补齐释放
+        target_loop = owner_loop if (owner_loop is not None and not owner_loop.is_closed()) else current_loop
+        if target_loop is None or target_loop.is_closed():
+            # 所有候选事件循环均不可用：挂起待下次进入可用事件循环时补齐释放
             self._pending_dispose_clients.append(stale_client)
             logger.debug("暂无可用于释放 LLM 客户端的事件循环，已挂起待下次进入事件循环时处理")
             return
@@ -691,8 +691,11 @@ class ClientRegistry:
         try:
             target_loop.call_soon_threadsafe(self._start_dispose_task, target_loop, stale_client)
         except RuntimeError:
-            # 目标循环已终止，其上的连接资源已随之结束，无法也无需再调度异步关闭
-            logger.warning("LLM 客户端所属事件循环已关闭，跳过其连接池释放")
+            # 目标循环在调用时刚关闭：回退到当前可用循环释放或挂起
+            if current_loop is not None and not current_loop.is_closed():
+                self._start_dispose_task(current_loop, stale_client)
+            else:
+                self._pending_dispose_clients.append(stale_client)
 
     def _schedule_dispose(
         self,
@@ -750,11 +753,15 @@ class ClientRegistry:
             for cache_key in list(self.client_instance_cache)
             if cache_key[0] is not None and cache_key[0].is_closed()
         ]
+        if not closed_keys:
+            return
+        current_loop = self._get_running_loop()
         stale_entries: List[Tuple[BaseClient, "asyncio.AbstractEventLoop | None"]] = []
         for cache_key in closed_keys:
             client = self.client_instance_cache.pop(cache_key, None)
             if client is not None:
-                stale_entries.append((client, cache_key[0]))
+                # 原循环已关闭，直接在当前活动循环上调度关闭
+                stale_entries.append((client, current_loop))
         if stale_entries:
             self._schedule_dispose(stale_entries)
 

--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator, Callable, Coroutine, Dict, List, Optional
 import asyncio
 import base64
 import binascii
+import contextlib
 import io
 import json
 import uuid
@@ -634,12 +635,14 @@ async def _default_stream_response_handler(
     last_response: GenerateContentResponse | None = None
 
     try:
-        async for chunk in response_stream:
-            last_response = chunk
-            if interrupt_flag and interrupt_flag.is_set():
-                raise ReqAbortException("请求被外部信号中断")
-            _process_stream_chunk(chunk, content_buffer, reasoning_buffer, tool_calls_buffer)
-            usage_record = _extract_usage_record(chunk) or usage_record
+        # 中断/解析异常路径下显式关闭底层流（async generator），避免连接滞留到 GC 才释放。
+        async with contextlib.aclosing(response_stream):
+            async for chunk in response_stream:
+                last_response = chunk
+                if interrupt_flag and interrupt_flag.is_set():
+                    raise ReqAbortException("请求被外部信号中断")
+                _process_stream_chunk(chunk, content_buffer, reasoning_buffer, tool_calls_buffer)
+                usage_record = _extract_usage_record(chunk) or usage_record
         return (
             _build_stream_api_response(
                 content_buffer,

--- a/src/llm_models/model_client/openai_client.py
+++ b/src/llm_models/model_client/openai_client.py
@@ -1245,7 +1245,10 @@ async def _default_stream_response_handler(
     finally:
         accumulator.close()
         # 中断/解析异常路径下显式关闭底层流，避免 SSE 连接滞留到 GC 才释放。
-        await resp_stream.close()
+        try:
+            await resp_stream.close()
+        except Exception as close_exc:
+            logger.debug(f"关闭 OpenAI 流式响应对象失败: {close_exc}")
 
 
 def _default_normal_response_parser(

--- a/src/llm_models/model_client/openai_client.py
+++ b/src/llm_models/model_client/openai_client.py
@@ -1244,6 +1244,8 @@ async def _default_stream_response_handler(
         return response, usage_record
     finally:
         accumulator.close()
+        # 中断/解析异常路径下显式关闭底层流，避免 SSE 连接滞留到 GC 才释放。
+        await resp_stream.close()
 
 
 def _default_normal_response_parser(

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -873,6 +873,36 @@ class LLMOrchestrator:
         request: ClientRequest,
         retry_limit: Optional[int] = None,
     ) -> APIResponse:
+        """持有客户端请求租约执行单模型请求，避免淘汰流程在请求进行中关闭其连接池。
+
+        Args:
+            api_provider: 当前请求对应的 API 提供商配置。
+            client: 已初始化的客户端实例。
+            request: 统一客户端请求对象。
+            retry_limit: 显式指定的重试次数；未指定时使用 Provider 配置。
+
+        Returns:
+            APIResponse: 统一响应对象。
+
+        Raises:
+            ModelAttemptFailed: 当当前模型重试耗尽或遇到硬错误时抛出。
+        """
+        client.acquire_request_lease()
+        try:
+            return await self._attempt_request_on_model_with_retry(api_provider, client, request, retry_limit)
+        finally:
+            client.release_request_lease()
+            # 实例已被注册表淘汰且本请求是最后一个使用者时，由请求方负责关闭连接池
+            if client.should_close_after_release():
+                await client.aclose()
+
+    async def _attempt_request_on_model_with_retry(
+        self,
+        api_provider: APIProvider,
+        client: BaseClient,
+        request: ClientRequest,
+        retry_limit: Optional[int] = None,
+    ) -> APIResponse:
         """在单个模型上执行请求，并处理重试逻辑。
 
         Args:

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -873,36 +873,6 @@ class LLMOrchestrator:
         request: ClientRequest,
         retry_limit: Optional[int] = None,
     ) -> APIResponse:
-        """持有客户端请求租约执行单模型请求，避免淘汰流程在请求进行中关闭其连接池。
-
-        Args:
-            api_provider: 当前请求对应的 API 提供商配置。
-            client: 已初始化的客户端实例。
-            request: 统一客户端请求对象。
-            retry_limit: 显式指定的重试次数；未指定时使用 Provider 配置。
-
-        Returns:
-            APIResponse: 统一响应对象。
-
-        Raises:
-            ModelAttemptFailed: 当当前模型重试耗尽或遇到硬错误时抛出。
-        """
-        client.acquire_request_lease()
-        try:
-            return await self._attempt_request_on_model_with_retry(api_provider, client, request, retry_limit)
-        finally:
-            client.release_request_lease()
-            # 实例已被注册表淘汰且本请求是最后一个使用者时，由请求方负责关闭连接池
-            if client.should_close_after_release():
-                await client.aclose()
-
-    async def _attempt_request_on_model_with_retry(
-        self,
-        api_provider: APIProvider,
-        client: BaseClient,
-        request: ClientRequest,
-        retry_limit: Optional[int] = None,
-    ) -> APIResponse:
         """在单个模型上执行请求，并处理重试逻辑。
 
         Args:
@@ -1213,20 +1183,24 @@ class LLMOrchestrator:
                 exclude_models=failed_models_this_request,
                 model_name=model_name,
             )
-            last_model_name = model_info.name
-            trace_context.model_attempt = 0
-            context_items: List[ContextItem] = []
-            if context_factory:
-                parameter_count = len(inspect.signature(context_factory).parameters)
-                if parameter_count >= 2:
-                    context_result = context_factory(client, model_info)
-                else:
-                    context_result = context_factory(client)
-                if inspect.isawaitable(context_result):
-                    context_items = await context_result
-                else:
-                    context_items = context_result
+            # 取得实例后立即登记租约：与获取之间不存在任何挂起点，
+            # 避免此窗口内配置重载把无租约的实例视为空闲并立即关闭其连接池
+            client.acquire_request_lease()
             try:
+                last_model_name = model_info.name
+                trace_context.model_attempt = 0
+                context_items: List[ContextItem] = []
+                if context_factory:
+                    parameter_count = len(inspect.signature(context_factory).parameters)
+                    if parameter_count >= 2:
+                        context_result = context_factory(client, model_info)
+                    else:
+                        context_result = context_factory(client)
+                    if inspect.isawaitable(context_result):
+                        context_items = await context_result
+                    else:
+                        context_items = context_result
+
                 request = self._build_client_request(
                     request_type=request_type,
                     model_info=model_info,
@@ -1294,6 +1268,15 @@ class LLMOrchestrator:
                 if isinstance(last_exception, RespNotOkException) and last_exception.status_code == 400:
                     logger.warning("收到客户端错误 (400)，跳过当前模型并继续尝试其他模型。")
                     continue
+            finally:
+                client.release_request_lease()
+                # 实例已被注册表淘汰且本请求是最后一个使用者时，由请求方负责关闭连接池；
+                # 关闭失败仅记录日志，不掩盖请求本身正在传播的异常语义
+                if client.should_close_after_release():
+                    try:
+                        await client.aclose()
+                    except Exception as close_error:
+                        logger.warning(f"释放已淘汰 LLM 客户端连接池失败: {close_error}")
 
         logger.error(f"所有 {max_attempts} 个模型均尝试失败。")
         if last_exception:

--- a/src/maisaka/memory/heuristic_injector.py
+++ b/src/maisaka/memory/heuristic_injector.py
@@ -22,6 +22,9 @@ logger = get_logger("maisaka_heuristic_memory")
 HEURISTIC_MEMORY_REFERENCE_MARKER = "【启发式记忆-内部参考】"
 _SOURCE_CHAT_SUMMARY_PREFIX = "chat_summary:"
 _SOURCE_PERSON_FACT_PREFIX = "person_fact:"
+# 会话状态保留时长：超过该时长未被访问的状态会被清理，
+# 防止状态字典随历史会话数无界增长。
+_STATE_RETENTION_SECONDS = 24 * 60 * 60
 
 
 def _get_int_config(config: Any, name: str, default: int) -> int:
@@ -37,6 +40,7 @@ class HeuristicMemoryRecallState:
 
     last_recall_at: float = 0.0
     last_message_count: int = 0
+    last_seen_at: float = 0.0
     cached_reference: str = ""
     cache_expires_at: float = 0.0
 
@@ -86,6 +90,8 @@ class HeuristicMemoryInjector:
 
         state = self._states.setdefault(session.session_id, HeuristicMemoryRecallState())
         now = time()
+        state.last_seen_at = now
+        self._prune_stale_states(now)
         cache_ttl = max(0, _get_int_config(config, "heuristic_memory_recall_cache_ttl_seconds", 300))
         if state.cached_reference and cache_ttl > 0 and now < state.cache_expires_at:
             return state.cached_reference
@@ -156,6 +162,17 @@ class HeuristicMemoryInjector:
             return
         state.cached_reference = ""
         state.cache_expires_at = 0.0
+
+    def _prune_stale_states(self, now: float) -> None:
+        """清理长时间未访问的会话状态，避免状态字典随历史会话数无界增长。"""
+
+        stale_ids = [
+            session_id
+            for session_id, state in self._states.items()
+            if now - state.last_seen_at > _STATE_RETENTION_SECONDS
+        ]
+        for session_id in stale_ids:
+            self._states.pop(session_id, None)
 
     @staticmethod
     def _can_trigger(

--- a/src/maisaka/reply_effect/tracker.py
+++ b/src/maisaka/reply_effect/tracker.py
@@ -344,6 +344,7 @@ class ReplyEffectTracker:
                 record.confidence_note = self._build_confidence_note(record)
                 record.followup_summary = self._build_followup_summary(record)
                 self._storage.save_record(record)
+                self._prune_finished_tracked_records()
                 return None
             record.status = ReplyEffectStatus.EVALUATING
             record.finalize_reason = reason
@@ -405,6 +406,36 @@ class ReplyEffectTracker:
             record.confidence_note = self._build_confidence_note(record)
             record.followup_summary = self._build_followup_summary(record)
             self._storage.save_record(record)
+        async with self._state_lock:
+            self._prune_finished_tracked_records()
+
+    def _prune_finished_tracked_records(self) -> None:
+        """移除已到终态且不再被未决记录引用的追踪记录，防止字典随回复数无界增长。
+
+        候选引用只在记录处于 PENDING/EVALUATING 时产生与消费，因此终态记录
+        一旦没有任何活跃记录引用即可安全移除（磁盘上的记录文件不受影响）。
+        调用方必须持有 ``self._state_lock``。
+        """
+
+        if not self._tracked_records:
+            return
+        active_statuses = {ReplyEffectStatus.PENDING, ReplyEffectStatus.EVALUATING}
+        referenced_ids = {
+            candidate_id
+            for record in self._tracked_records.values()
+            if record.status in active_statuses
+            for followup in record.followup_messages
+            for candidate_id in followup.candidate_effect_ids
+        }
+        terminal_statuses = {
+            ReplyEffectStatus.FINALIZED,
+            ReplyEffectStatus.INCOMPLETE,
+            ReplyEffectStatus.EVALUATION_FAILED,
+        }
+        for effect_id in list(self._tracked_records):
+            tracked = self._tracked_records[effect_id]
+            if tracked.status in terminal_statuses and effect_id not in referenced_ids:
+                del self._tracked_records[effect_id]
 
     async def _apply_associations(self, evaluated: Dict[str, list[ReplyAssociation]]) -> None:
         """把一次批量评审的关联边同步到所有仍保留的候选记录。"""

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -75,6 +75,8 @@ logger = get_logger("maisaka_runtime")
 
 MAX_INTERNAL_ROUNDS = 10
 MAX_RETAINED_MESSAGE_CACHE_SIZE = 200
+# 心流周期记录仅用于调试观察，保留最近若干条即可，避免长期运行时无界增长。
+HISTORY_LOOP_MAX_LENGTH = 200
 CONTEXT_RESTORE_FILL_RATIO = 0.5
 CONTEXT_RESTORE_SHORT_RESTART_SECONDS = 5 * 60
 CONTEXT_RESTORE_SHORT_OFFLINE_SECONDS = 30 * 60
@@ -158,7 +160,7 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
             is_group_chat=self.chat_stream.is_group_session,
         )
         self._chat_history: list[LLMContextMessage] = []
-        self.history_loop: list[CycleDetail] = []
+        self.history_loop: deque[CycleDetail] = deque(maxlen=HISTORY_LOOP_MAX_LENGTH)
 
         # Keep all original messages for batching and later learning.
         self.message_cache: list[SessionMessage] = []

--- a/src/plugin_runtime/capabilities/core.py
+++ b/src/plugin_runtime/capabilities/core.py
@@ -188,30 +188,31 @@ class RuntimeCoreCapabilityMixin:
             from src.maisaka.context.message_adapter import build_visible_text_from_sequence
             from src.plugin_runtime.host.message_utils import PluginMessageUtils
 
-            runtime = await heartflow_manager.get_or_create_heartflow_chat(stream_id)
-            message_sequence = PluginMessageUtils._message_sequence_from_dict(segments)
-            visible_text = str(args.get("visible_text") or "").strip()
-            if not visible_text:
-                visible_text = build_visible_text_from_sequence(message_sequence)
-            if not visible_text:
-                visible_text = "[插件上下文消息]"
+            # 以使用租约借用运行时，避免租约期间被释放/淘汰流程停止
+            async with heartflow_manager.borrow_chat(stream_id) as runtime:
+                message_sequence = PluginMessageUtils._message_sequence_from_dict(segments)
+                visible_text = str(args.get("visible_text") or "").strip()
+                if not visible_text:
+                    visible_text = build_visible_text_from_sequence(message_sequence)
+                if not visible_text:
+                    visible_text = "[插件上下文消息]"
 
-            source_kind = str(args.get("source_kind") or f"plugin:{plugin_id}").strip() or f"plugin:{plugin_id}"
-            context_message = SessionBackedMessage(
-                raw_message=message_sequence,
-                visible_text=visible_text,
-                timestamp=datetime.now(),
-                message_id=str(args.get("message_id") or "").strip() or None,
-                source_kind=source_kind,
-            )
-            runtime._chat_history.append(context_message)
-            return {
-                "success": True,
-                "index": len(runtime._chat_history) - 1,
-                "stream_id": stream_id,
-                "visible_text": visible_text,
-                "source_kind": source_kind,
-            }
+                source_kind = str(args.get("source_kind") or f"plugin:{plugin_id}").strip() or f"plugin:{plugin_id}"
+                context_message = SessionBackedMessage(
+                    raw_message=message_sequence,
+                    visible_text=visible_text,
+                    timestamp=datetime.now(),
+                    message_id=str(args.get("message_id") or "").strip() or None,
+                    source_kind=source_kind,
+                )
+                runtime._chat_history.append(context_message)
+                return {
+                    "success": True,
+                    "index": len(runtime._chat_history) - 1,
+                    "stream_id": stream_id,
+                    "visible_text": visible_text,
+                    "source_kind": source_kind,
+                }
         except Exception as exc:
             logger.error(f"[cap.maisaka.context.append] 执行失败: {exc}", exc_info=True)
             return {"success": False, "error": str(exc)}
@@ -236,15 +237,16 @@ class RuntimeCoreCapabilityMixin:
             if chat_session is None:
                 return {"success": False, "error": f"未找到已存在的聊天流: {stream_id}"}
 
-            runtime = await heartflow_manager.get_or_create_heartflow_chat(stream_id)
-            result = await runtime.enqueue_proactive_task(
-                plugin_id=plugin_id,
-                intent=intent,
-                reason=str(args.get("reason") or "").strip(),
-                priority=str(args.get("priority") or "").strip(),
-                metadata=args.get("metadata") if isinstance(args.get("metadata"), dict) else None,
-            )
-            return {"success": True, **result}
+            # 以使用租约借用运行时，避免租约期间被释放/淘汰流程停止
+            async with heartflow_manager.borrow_chat(stream_id) as runtime:
+                result = await runtime.enqueue_proactive_task(
+                    plugin_id=plugin_id,
+                    intent=intent,
+                    reason=str(args.get("reason") or "").strip(),
+                    priority=str(args.get("priority") or "").strip(),
+                    metadata=args.get("metadata") if isinstance(args.get("metadata"), dict) else None,
+                )
+                return {"success": True, **result}
         except Exception as exc:
             logger.error(f"[cap.maisaka.proactive.trigger] 执行失败: {exc}", exc_info=True)
             return {"success": False, "error": str(exc)}

--- a/src/plugin_runtime/capabilities/data.py
+++ b/src/plugin_runtime/capabilities/data.py
@@ -437,6 +437,23 @@ class RuntimeDataCapabilityMixin:
             logger.error(f"[cap.message.get_by_id] 执行失败: {e}", exc_info=True)
             return {"success": False, "error": str(e)}
 
+    # 插件消息查询的单次返回上限：仓储层把 limit<=0 视为"不限制"，
+    # 直接透传会让插件一次调用就把全量历史物化进内存，必须钳制。
+    MAX_PLUGIN_MESSAGE_LIMIT = 500
+    DEFAULT_PLUGIN_MESSAGE_LIMIT = 100
+
+    @classmethod
+    def _normalize_message_limit(cls, args: Dict[str, Any]) -> int:
+        """解析插件传入的消息条数上限：缺失/非法/<=0 一律回退默认值，并限制最大值。"""
+
+        try:
+            limit = int(args.get("limit") or 0)
+        except (TypeError, ValueError):
+            limit = 0
+        if limit <= 0:
+            return cls.DEFAULT_PLUGIN_MESSAGE_LIMIT
+        return min(limit, cls.MAX_PLUGIN_MESSAGE_LIMIT)
+
     async def _cap_message_get_by_time(self, plugin_id: str, capability: str, args: Dict[str, Any]) -> Any:
         from src.services import message_service 
 
@@ -444,7 +461,7 @@ class RuntimeDataCapabilityMixin:
             messages = message_service.get_messages_by_time(
                 start_time=float(args.get("start_time", 0.0)),
                 end_time=float(args.get("end_time", 0.0)),
-                limit=args.get("limit", 0),
+                limit=self._normalize_message_limit(args),
                 limit_mode=args.get("limit_mode", "latest"),
                 filter_mai=args.get("filter_mai", False),
             )
@@ -471,7 +488,7 @@ class RuntimeDataCapabilityMixin:
                 chat_id=chat_id,
                 start_time=float(args.get("start_time", 0.0)),
                 end_time=float(args.get("end_time", 0.0)),
-                limit=args.get("limit", 0),
+                limit=self._normalize_message_limit(args),
                 limit_mode=args.get("limit_mode", "latest"),
                 filter_mai=args.get("filter_mai", False),
                 filter_command=args.get("filter_command", False),
@@ -503,7 +520,7 @@ class RuntimeDataCapabilityMixin:
                 chat_id=chat_id,
                 start_time=current_time - hours * 3600,
                 end_time=current_time,
-                limit=args.get("limit", 100),
+                limit=self._normalize_message_limit(args),
                 limit_mode=args.get("limit_mode", "latest"),
                 filter_mai=args.get("filter_mai", False),
             )
@@ -550,7 +567,7 @@ class RuntimeDataCapabilityMixin:
                     chat_id=chat_id,
                     start_time=float(args.get("start_time", 0.0)),
                     end_time=float(args.get("end_time", 0.0)),
-                    limit=args.get("limit", 0),
+                    limit=self._normalize_message_limit(args),
                 )
             else:
                 messages = self._deserialize_messages(messages)

--- a/src/plugin_runtime/host/circuit_breaker.py
+++ b/src/plugin_runtime/host/circuit_breaker.py
@@ -1,7 +1,7 @@
 """插件运行时熔断器。"""
 
 from dataclasses import dataclass
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Iterable, Literal
 
 import time
 
@@ -180,6 +180,24 @@ class PluginCircuitBreaker:
             return
         state.cooldown_level = 0
         state.last_recovered_at = 0.0
+
+    def forget_plugins(self, plugin_ids: Iterable[str]) -> int:
+        """清除指定插件（例如已卸载）的熔断状态，避免状态按插件 ID 无限累积。
+
+        Args:
+            plugin_ids: 待清除状态的插件 ID 列表。
+
+        Returns:
+            int: 实际清除的插件状态数量。
+        """
+        removed_count = 0
+        for plugin_id in plugin_ids:
+            normalized_plugin_id = str(plugin_id or "").strip()
+            if not normalized_plugin_id:
+                continue
+            if self._states.pop(normalized_plugin_id, None) is not None:
+                removed_count += 1
+        return removed_count
 
     def get_plugin_statuses(self) -> Dict[str, Dict[str, Any]]:
         """返回当前存在熔断状态的插件快照。"""

--- a/src/plugin_runtime/host/circuit_breaker.py
+++ b/src/plugin_runtime/host/circuit_breaker.py
@@ -28,6 +28,8 @@ class CircuitPermit:
     allowed: bool
     half_open: bool = False
     reason: str = ""
+    bound_state: "_CircuitState | None" = None
+    """获取许可时绑定的熔断状态对象；被 forget_plugins 清理后失效。"""
 
 
 @dataclass(slots=True)
@@ -79,6 +81,7 @@ class PluginCircuitBreaker:
                 operation=operation,
                 allowed=False,
                 reason=f"插件熔断中，剩余 {remaining_sec:.1f}s",
+                bound_state=state,
             )
 
         if state.state == "open" and now >= state.opened_until:
@@ -94,6 +97,7 @@ class PluginCircuitBreaker:
                     operation=operation,
                     allowed=False,
                     reason="插件半开测试已有进行中的调用",
+                    bound_state=state,
                 )
             state.half_open_inflight = True
             return CircuitPermit(
@@ -102,6 +106,7 @@ class PluginCircuitBreaker:
                 operation=operation,
                 allowed=True,
                 half_open=True,
+                bound_state=state,
             )
 
         return CircuitPermit(
@@ -109,7 +114,21 @@ class PluginCircuitBreaker:
             component_name=component_name,
             operation=operation,
             allowed=True,
+            bound_state=state,
         )
+
+    def _resolve_bound_state(self, permit: CircuitPermit) -> _CircuitState | None:
+        """解析许可绑定的熔断状态；绑定已失效时返回 None。
+
+        许可绑定的状态对象若已被 ``forget_plugins`` 清理（如插件卸载），
+        或同 ID 插件重载后状态被重建，则本次完成回调直接忽略：
+        避免在途调用通过 setdefault 重建已清理的状态，或把结果写入新插件的状态。
+        """
+        state = self._states.get(permit.plugin_id)
+        if state is None or state is not permit.bound_state:
+            logger.debug(f"插件 {permit.plugin_id} 的熔断许可已失效，忽略本次调用结果记录")
+            return None
+        return state
 
     def record_success(self, permit: CircuitPermit) -> None:
         """记录一次插件调用成功。"""
@@ -117,8 +136,11 @@ class PluginCircuitBreaker:
         if not permit.allowed:
             return
 
+        state = self._resolve_bound_state(permit)
+        if state is None:
+            return
+
         now = time.monotonic()
-        state = self._states.setdefault(permit.plugin_id, _CircuitState())
         was_half_open = state.state == "half_open" or permit.half_open
         self._reset_cooldown_if_stable(state, now)
         state.consecutive_failures = 0
@@ -137,8 +159,11 @@ class PluginCircuitBreaker:
         if not permit.allowed:
             return
 
+        state = self._resolve_bound_state(permit)
+        if state is None:
+            return
+
         now = time.monotonic()
-        state = self._states.setdefault(permit.plugin_id, _CircuitState())
         self._reset_cooldown_if_stable(state, now)
         state.half_open_inflight = False
 

--- a/src/plugin_runtime/host/event_dispatcher.py
+++ b/src/plugin_runtime/host/event_dispatcher.py
@@ -153,7 +153,7 @@ class EventDispatcher:
                     **(extra_args or {}),
                 }
                 # 非阻塞：保持实例级强引用，防止 task 被 GC 回收
-                task = asyncio.create_task(self._invoke_handler(supervisor, entry, args, event_type))
+                task = asyncio.create_task(self._invoke_background_handler(supervisor, entry, args, event_type))
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
         try:
@@ -169,6 +169,24 @@ class EventDispatcher:
             logger.error(f"构建修改后的 SessionMessage 失败: {e}")
             modified_message_obj = None
         return should_continue, modified_message_obj
+
+    async def _invoke_background_handler(
+        self,
+        supervisor: "PluginRunnerSupervisor",
+        handler_entry: "EventHandlerEntry",
+        args: Dict[str, Any],
+        event_type: str,
+    ) -> Optional[EventResult]:
+        """后台执行非阻塞处理器，启动前重新校验条目注册状态。
+
+        任务入队到真正启动之间插件可能已被卸载/重载：
+        若不校验，旧任务会通过 try_acquire 的 setdefault 重建已清理的熔断状态，
+        或把结果写入同 ID 重载后插件的新状态。
+        """
+        if handler_entry not in self._component_registry.get_event_handlers(event_type):
+            logger.debug(f"EventHandler {handler_entry.full_name} 已注销或被禁用，跳过后台执行")
+            return None
+        return await self._invoke_handler(supervisor, handler_entry, args, event_type)
 
     async def _invoke_handler(
         self,

--- a/src/plugin_runtime/host/hook_dispatcher.py
+++ b/src/plugin_runtime/host/hook_dispatcher.py
@@ -406,6 +406,33 @@ class HookDispatcher:
             return hook_spec.default_timeout_ms
         return self._get_default_timeout_ms()
 
+    async def _invoke_hook_handler_if_registered(
+        self,
+        hook_name: str,
+        hook_spec: HookSpec,
+        target: _HookInvocationTarget,
+        kwargs: Dict[str, Any],
+    ) -> HookHandlerExecutionResult:
+        """校验处理器条目仍注册后执行；供后台观察任务使用。
+
+        任务入队到真正启动之间插件可能已被卸载/重载：
+        若不校验，旧任务会通过 try_acquire 的 setdefault 重建已清理的熔断状态，
+        或把结果写入同 ID 重载后插件的新状态。
+        """
+        current_entries = target.supervisor.component_registry.get_hook_handlers(hook_name)
+        if target.entry not in current_entries:
+            logger.debug(f"HookHandler {target.entry.full_name} 已注销或被禁用，跳过观察执行")
+            return HookHandlerExecutionResult(
+                handler_name=target.entry.full_name,
+                plugin_id=target.entry.plugin_id,
+            )
+        return await self._invoke_handler(
+            hook_name=hook_name,
+            hook_spec=hook_spec,
+            target=target,
+            kwargs=kwargs,
+        )
+
     async def _invoke_handler(
         self,
         hook_name: str,
@@ -678,7 +705,7 @@ class HookDispatcher:
             kwargs: 调用参数快照。
         """
 
-        execution_result = await self._invoke_handler(
+        execution_result = await self._invoke_hook_handler_if_registered(
             hook_name=hook_name,
             hook_spec=hook_spec,
             target=target,

--- a/src/plugin_runtime/host/rpc_server.py
+++ b/src/plugin_runtime/host/rpc_server.py
@@ -235,6 +235,12 @@ class RPCServer:
             self._pending_requests.pop(request_id, None)
             self._pending_request_metadata.pop(request_id, None)
             raise RPCError(ErrorCode.E_TIMEOUT, f"请求 {method} 超时 ({timeout_ms}ms)") from None
+        except asyncio.CancelledError:
+            # 调用方任务被取消时 future 已无消费者，必须清理登记，
+            # 否则条目会滞留到断连/停机才批量回收。
+            self._pending_requests.pop(request_id, None)
+            self._pending_request_metadata.pop(request_id, None)
+            raise
         except Exception as e:
             self._pending_requests.pop(request_id, None)
             self._pending_request_metadata.pop(request_id, None)

--- a/src/plugin_runtime/host/supervisor.py
+++ b/src/plugin_runtime/host/supervisor.py
@@ -247,6 +247,21 @@ class PluginRunnerSupervisor:
 
         return _RUNNER_DEBUG_FILE_PATH.resolve()
 
+    # 诊断文件单代大小上限：健康检查等事件按固定频率持续追加，
+    # 超过上限即轮转一代（仅保留 .1），防止文件跨重启无界增长。
+    DEBUG_FILE_MAX_BYTES = 16 * 1024 * 1024
+
+    def _rotate_debug_file_if_needed(self, debug_file: Path) -> None:
+        """诊断文件超限时轮转一代；与 Runner 多进程并发轮转失败时跳过本次即可。"""
+
+        try:
+            if not debug_file.exists() or debug_file.stat().st_size < self.DEBUG_FILE_MAX_BYTES:
+                return
+            rotated = debug_file.with_name(f"{debug_file.stem}.1{debug_file.suffix}")
+            os.replace(debug_file, rotated)
+        except Exception as exc:
+            self._logger.warning(f"轮转插件运行时 Host 诊断文件失败: {exc}")
+
     def _write_debug_event_sync(self, event: str, payload: Dict[str, Any]) -> None:
         """将 Host 侧插件运行时诊断事件写入独立 JSONL 文件。"""
 
@@ -261,6 +276,7 @@ class PluginRunnerSupervisor:
         try:
             debug_file = self._debug_file_path()
             debug_file.parent.mkdir(parents=True, exist_ok=True)
+            self._rotate_debug_file_if_needed(debug_file)
             with open(debug_file, "a", encoding="utf-8") as handle:
                 handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
         except Exception as exc:

--- a/src/plugin_runtime/host/supervisor.py
+++ b/src/plugin_runtime/host/supervisor.py
@@ -75,6 +75,7 @@ from src.services.bot_account_service import (
 from .authorization import AuthorizationManager
 from .api_registry import APIRegistry
 from .capability_service import CapabilityService
+from .circuit_breaker import get_plugin_circuit_breaker
 from .component_registry import ComponentRegistry
 from .event_dispatcher import EventDispatcher
 from .hook_dispatcher import HookDispatchResult, HookDispatcher
@@ -1189,6 +1190,7 @@ class PluginRunnerSupervisor:
             removed_llm_providers = client_registry.unregister_plugin_providers(payload.plugin_id)
         self._authorization.revoke_permission_token(payload.plugin_id)
         removed_registration = self._registered_plugins.pop(payload.plugin_id, None) is not None
+        get_plugin_circuit_breaker().forget_plugins([payload.plugin_id])
         await self._unregister_all_message_gateway_drivers_for_plugin(payload.plugin_id)
         self._message_gateway_states.pop(payload.plugin_id, None)
 

--- a/src/plugin_runtime/host/supervisor.py
+++ b/src/plugin_runtime/host/supervisor.py
@@ -2054,6 +2054,8 @@ class PluginRunnerSupervisor:
             for plugin_id, registration in list(self._registered_plugins.items()):
                 if registration.llm_providers:
                     client_registry.unregister_plugin_providers(plugin_id)
+        # 清空注册表前同步清理各插件的熔断状态，避免同 ID 插件重载后继承旧状态
+        get_plugin_circuit_breaker().forget_plugins(list(self._registered_plugins.keys()))
         self._authorization.clear()
         self._api_registry.clear()
         self._component_registry.clear()

--- a/src/plugin_runtime/runner/plugin_loader.py
+++ b/src/plugin_runtime/runner/plugin_loader.py
@@ -333,12 +333,13 @@ class PluginLoader:
         return self._loaded_plugins.get(plugin_id)
 
     def set_loaded_plugin(self, meta: PluginMeta) -> None:
-        """登记一个已经完成初始化的插件。
+        """登记一个已经完成初始化的插件，并清除其历史失败记录。
 
         Args:
             meta: 待登记的插件元数据。
         """
         self._loaded_plugins[meta.plugin_id] = meta
+        self._failed_plugins.pop(meta.plugin_id, None)
 
     def remove_loaded_plugin(self, plugin_id: str) -> Optional[PluginMeta]:
         """移除一个已加载插件的元数据。

--- a/src/plugin_runtime/runner/rpc_client.py
+++ b/src/plugin_runtime/runner/rpc_client.py
@@ -210,6 +210,11 @@ class RPCClient:
         except asyncio.TimeoutError:
             self._pending_requests.pop(request_id, None)
             raise RPCError(ErrorCode.E_TIMEOUT, f"请求 {method} 超时 ({timeout_ms}ms)") from None
+        except asyncio.CancelledError:
+            # 调用方任务被取消时 future 已无消费者，必须清理登记，
+            # 否则条目会滞留到断连/停机才批量回收。
+            self._pending_requests.pop(request_id, None)
+            raise
         except Exception as exc:
             self._pending_requests.pop(request_id, None)
             if isinstance(exc, RPCError):

--- a/src/plugin_runtime/runner/runner_main.py
+++ b/src/plugin_runtime/runner/runner_main.py
@@ -571,6 +571,21 @@ class PluginRunner:
             summary["operation"] = operation
         return summary
 
+    # 诊断文件单代大小上限：健康检查等事件按固定频率持续追加，
+    # 超过上限即轮转一代（仅保留 .1），防止文件跨重启无界增长。
+    DEBUG_FILE_MAX_BYTES = 16 * 1024 * 1024
+
+    def _rotate_debug_file_if_needed(self, debug_file: Path) -> None:
+        """诊断文件超限时轮转一代；多进程并发轮转失败时跳过本次即可。"""
+
+        try:
+            if not debug_file.exists() or debug_file.stat().st_size < self.DEBUG_FILE_MAX_BYTES:
+                return
+            rotated = debug_file.with_name(f"{debug_file.stem}.1{debug_file.suffix}")
+            os.replace(debug_file, rotated)
+        except Exception as exc:
+            logger.warning(f"轮转 Runner RPC 诊断文件失败: {exc}")
+
     def _write_debug_event_sync(self, event: str, payload: Dict[str, Any]) -> None:
         """把 Runner 诊断事件追加到独立 JSONL 文件。"""
 
@@ -586,6 +601,7 @@ class PluginRunner:
         try:
             debug_file = self._debug_file_path()
             debug_file.parent.mkdir(parents=True, exist_ok=True)
+            self._rotate_debug_file_if_needed(debug_file)
             with open(debug_file, "a", encoding="utf-8") as handle:
                 handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
         except Exception as exc:

--- a/src/services/llm_cache_stats.py
+++ b/src/services/llm_cache_stats.py
@@ -27,6 +27,9 @@ REPORT_INTERVAL_SECONDS = 300
 REPORT_INTERVAL_CALLS = 50
 SUMMARY_LIMIT = 5
 PROMPT_CACHE_POOL_SIZE = 128
+# 统计键包含 session_id，长期运行会随会话数量无界增长；
+# 超过上限后按插入顺序 FIFO 淘汰最旧的键（调试统计用途，淘汰不影响正确性）。
+MAX_CACHE_STATS_KEYS = 256
 CACHE_STATS_DIR = Path("logs") / "llm_cache_stats"
 REPORT_FILE_NAME = "report.html"
 SESSION_REPORT_FILE_NAME = "sessions.html"
@@ -206,6 +209,17 @@ def _normalize_model_name(model_name: str) -> str:
 def _normalize_session_id(session_id: str) -> str:
     normalized = str(session_id or "").strip()
     return normalized or "unknown"
+
+
+def _evict_oldest_cache_stats_keys_locked() -> None:
+    """限制统计键数量，防止 stats/prompt_pools 随会话数无界增长（需持有 _store.lock）。"""
+
+    overflow = len(_store.stats) - MAX_CACHE_STATS_KEYS
+    if overflow <= 0:
+        return
+    for key in list(_store.stats)[:overflow]:
+        _store.stats.pop(key, None)
+        _store.prompt_pools.pop(key, None)
 
 
 def _normalize_cache_tokens(
@@ -1373,6 +1387,7 @@ def record_llm_cache_usage(
                 session_id=normalized_session_id,
             )
             _store.stats[key] = stat
+            _evict_oldest_cache_stats_keys_locked()
 
         stat.calls += 1
         stat.prompt_tokens += normalized_prompt_tokens

--- a/src/services/memory_flow_service.py
+++ b/src/services/memory_flow_service.py
@@ -422,6 +422,13 @@ class PersonFactWritebackService:
 class ChatSummaryWritebackState:
     last_trigger_message_count: int = 0
     last_trigger_time: float = 0.0
+    # 状态最近一次被访问的时间，用于清理长期不活跃的会话状态。
+    last_accessed_at: float = 0.0
+
+
+# 会话写回状态的内存保留时长：超过该时长未被访问的状态会被清理，
+# 需要时会重新从数据库恢复触发位点，不影响正确性。
+_STATE_RETENTION_SECONDS = 7 * 24 * 60 * 60
 
 
 class ChatSummaryWritebackService:
@@ -450,6 +457,18 @@ class ChatSummaryWritebackService:
             pass
         except Exception as exc:
             logger.warning(f"关闭聊天摘要写回 worker 失败: {exc}")
+
+    def _prune_stale_states(self) -> None:
+        """清理长时间未访问的会话状态，避免字典随历史会话数无界增长。"""
+
+        cutoff = time.time() - _STATE_RETENTION_SECONDS
+        stale_ids = [
+            session_id
+            for session_id, state in self._states.items()
+            if state.last_accessed_at < cutoff
+        ]
+        for session_id in stale_ids:
+            self._states.pop(session_id, None)
 
     async def enqueue(self, message: Any) -> None:
         if not bool(global_config.a_memorix.integration.chat_summary_writeback_enabled):
@@ -494,8 +513,12 @@ class ChatSummaryWritebackService:
             state = ChatSummaryWritebackState(
                 last_trigger_message_count=restored_count,
                 last_trigger_time=time.time() if restored_count > 0 else 0.0,
+                last_accessed_at=time.time(),
             )
             self._states[session_id] = state
+            self._prune_stale_states()
+        else:
+            state.last_accessed_at = time.time()
         pending_message_count = max(0, total_message_count - state.last_trigger_message_count)
         if pending_message_count < threshold:
             return

--- a/src/services/memory_flow_service.py
+++ b/src/services/memory_flow_service.py
@@ -437,6 +437,7 @@ class ChatSummaryWritebackService:
         self._worker_task: Optional[asyncio.Task] = None
         self._stopping = False
         self._states: dict[str, ChatSummaryWritebackState] = {}
+        self._last_prune_time: float = 0.0
 
     async def start(self) -> None:
         if self._worker_task is not None and not self._worker_task.done():

--- a/src/webui/core/rate_limiter.py
+++ b/src/webui/core/rate_limiter.py
@@ -72,8 +72,19 @@ class RateLimiter:
         for stale_key in stale_keys:
             del self._requests[stale_key]
         overflow = len(self._requests) - self.MAX_TRACKED_REQUEST_KEYS
-        for stale_key in list(self._requests)[:max(0, overflow)]:
+        if overflow <= 0:
+            return
+        # 优先淘汰常规请求键，保护处于活跃窗口内的认证失败记录，防止防爆破策略被大流量冲刷弱化。
+        for stale_key in list(self._requests):
+            if overflow <= 0:
+                break
+            if stale_key.endswith(":auth_failures"):
+                continue
             del self._requests[stale_key]
+            overflow -= 1
+        if overflow > 0:
+            for stale_key in list(self._requests)[:overflow]:
+                del self._requests[stale_key]
 
     def _cleanup_expired_blocks(self):
         """清理过期的封禁"""

--- a/src/webui/core/rate_limiter.py
+++ b/src/webui/core/rate_limiter.py
@@ -24,6 +24,7 @@ class RateLimiter:
     # 追踪的请求键（IP/规则组合）数量上限：公网环境下 IP 数可能持续增长，
     # 超过上限时清理过期键并淘汰最旧键，防止字典无界膨胀。
     MAX_TRACKED_REQUEST_KEYS = 10000
+    MAX_TRACKED_AUTH_FAILURE_KEYS = 5000
 
     def __init__(self):
         # 存储格式: {key: [(timestamp, count), ...]}
@@ -169,10 +170,23 @@ class RateLimiter:
         now = time.time()
         cutoff = now - window_seconds
 
-        # 在独立的认证失败存储中滑动清理
+        # 在独立的认证失败存储中清理所有已过期的 IP 记录，防止未再次请求的 IP 长期滞留
+        stale_ips = [
+            recorded_ip
+            for recorded_ip, records in self._auth_failures.items()
+            if all(ts <= cutoff for ts, _ in records)
+        ]
+        for stale_ip in stale_ips:
+            del self._auth_failures[stale_ip]
+
+        # 超过认证失败容量上限时按 FIFO 淘汰最旧的记录
+        auth_overflow = len(self._auth_failures) - self.MAX_TRACKED_AUTH_FAILURE_KEYS
+        if auth_overflow > 0:
+            for stale_ip in list(self._auth_failures)[:auth_overflow]:
+                del self._auth_failures[stale_ip]
+
+        # 过滤当前 IP 窗口内的记录
         self._auth_failures[ip] = [(ts, count) for ts, count in self._auth_failures[ip] if ts > cutoff]
-        if not self._auth_failures[ip]:
-            del self._auth_failures[ip]
 
         # 计算当前失败次数
         current_failures = sum(count for _, count in self._auth_failures[ip])

--- a/src/webui/core/rate_limiter.py
+++ b/src/webui/core/rate_limiter.py
@@ -21,6 +21,10 @@ class RateLimiter:
     使用滑动窗口算法实现
     """
 
+    # 追踪的请求键（IP/规则组合）数量上限：公网环境下 IP 数可能持续增长，
+    # 超过上限时清理过期键并淘汰最旧键，防止字典无界膨胀。
+    MAX_TRACKED_REQUEST_KEYS = 10000
+
     def __init__(self):
         # 存储格式: {key: [(timestamp, count), ...]}
         self._requests: Dict[str, List] = defaultdict(list)
@@ -50,6 +54,26 @@ class RateLimiter:
         now = time.time()
         cutoff = now - window_seconds
         self._requests[key] = [(ts, count) for ts, count in self._requests[key] if ts > cutoff]
+        # 窗口内已无记录的键直接删除，避免空键随历史 IP 数无界积累。
+        if not self._requests[key]:
+            del self._requests[key]
+        self._enforce_request_key_limit(cutoff)
+
+    def _enforce_request_key_limit(self, cutoff: float) -> None:
+        """限制追踪键总数：超限时先清除全部过期键，仍超额则按插入顺序淘汰最旧键。"""
+
+        if len(self._requests) <= self.MAX_TRACKED_REQUEST_KEYS:
+            return
+        stale_keys = [
+            stale_key
+            for stale_key, records in self._requests.items()
+            if all(ts <= cutoff for ts, _ in records)
+        ]
+        for stale_key in stale_keys:
+            del self._requests[stale_key]
+        overflow = len(self._requests) - self.MAX_TRACKED_REQUEST_KEYS
+        for stale_key in list(self._requests)[:max(0, overflow)]:
+            del self._requests[stale_key]
 
     def _cleanup_expired_blocks(self):
         """清理过期的封禁"""

--- a/src/webui/core/rate_limiter.py
+++ b/src/webui/core/rate_limiter.py
@@ -28,6 +28,8 @@ class RateLimiter:
     def __init__(self):
         # 存储格式: {key: [(timestamp, count), ...]}
         self._requests: Dict[str, List] = defaultdict(list)
+        # 独立存储认证失败记录，避免常规流量限流键的容量淘汰削弱防爆破封禁保护
+        self._auth_failures: Dict[str, List] = defaultdict(list)
         # 被封禁的 IP: {ip: unblock_timestamp}
         self._blocked: Dict[str, float] = {}
 
@@ -72,16 +74,6 @@ class RateLimiter:
         for stale_key in stale_keys:
             del self._requests[stale_key]
         overflow = len(self._requests) - self.MAX_TRACKED_REQUEST_KEYS
-        if overflow <= 0:
-            return
-        # 优先淘汰常规请求键，保护处于活跃窗口内的认证失败记录，防止防爆破策略被大流量冲刷弱化。
-        for stale_key in list(self._requests):
-            if overflow <= 0:
-                break
-            if stale_key.endswith(":auth_failures"):
-                continue
-            del self._requests[stale_key]
-            overflow -= 1
         if overflow > 0:
             for stale_key in list(self._requests)[:overflow]:
                 del self._requests[stale_key]
@@ -174,17 +166,19 @@ class RateLimiter:
             (是否被封禁, 剩余尝试次数)
         """
         ip = self._get_client_ip(request)
-        key = f"{ip}:auth_failures"
+        now = time.time()
+        cutoff = now - window_seconds
 
-        # 清理过期记录
-        self._cleanup_old_requests(key, window_seconds)
+        # 在独立的认证失败存储中滑动清理
+        self._auth_failures[ip] = [(ts, count) for ts, count in self._auth_failures[ip] if ts > cutoff]
+        if not self._auth_failures[ip]:
+            del self._auth_failures[ip]
 
         # 计算当前失败次数
-        current_failures = sum(count for _, count in self._requests[key])
+        current_failures = sum(count for _, count in self._auth_failures[ip])
 
         # 记录本次失败
-        now = time.time()
-        self._requests[key].append((now, 1))
+        self._auth_failures[ip].append((now, 1))
         current_failures += 1
 
         remaining = max_failures - current_failures
@@ -205,9 +199,8 @@ class RateLimiter:
         重置失败计数（认证成功后调用）
         """
         ip = self._get_client_ip(request)
-        key = f"{ip}:auth_failures"
-        if key in self._requests:
-            del self._requests[key]
+        self._auth_failures.pop(ip, None)
+        self._requests.pop(f"{ip}:auth_failures", None)
 
 
 # 全局单例

--- a/src/webui/logs_ws.py
+++ b/src/webui/logs_ws.py
@@ -148,17 +148,17 @@ async def websocket_logs(websocket: WebSocket, token: Optional[str] = Query(None
     active_connections.add(websocket)
     logger.info(f"📡 WebSocket 客户端已连接（已认证），当前连接数: {len(active_connections)}")
 
-    # 连接建立后，立即发送历史日志
     try:
-        recent_logs = load_recent_logs(limit=100)
-        logger.info(f"发送 {len(recent_logs)} 条历史日志到客户端")
+        # 连接建立后，立即发送历史日志
+        try:
+            recent_logs = load_recent_logs(limit=100)
+            logger.info(f"发送 {len(recent_logs)} 条历史日志到客户端")
 
-        for log_entry in recent_logs:
-            await websocket.send_text(json.dumps(log_entry, ensure_ascii=False))
-    except Exception as e:
-        logger.error(f"发送历史日志失败: {e}")
+            for log_entry in recent_logs:
+                await websocket.send_text(json.dumps(log_entry, ensure_ascii=False))
+        except Exception as e:
+            logger.error(f"发送历史日志失败: {e}")
 
-    try:
         # 保持连接，等待客户端消息或断开
         while True:
             # 接收客户端消息（用于心跳或控制指令）
@@ -171,10 +171,11 @@ async def websocket_logs(websocket: WebSocket, token: Optional[str] = Query(None
                 await websocket.send_text("pong")
 
     except WebSocketDisconnect:
-        active_connections.discard(websocket)
         logger.info(f"📡 WebSocket 客户端已断开，当前连接数: {len(active_connections)}")
     except Exception as e:
         logger.error(f"❌ WebSocket 错误: {e}")
+    finally:
+        # 无论正常断开、异常还是任务被取消（CancelledError 不会被 except Exception 捕获），都必须移除连接引用
         active_connections.discard(websocket)
 
 

--- a/src/webui/routers/chat/routes.py
+++ b/src/webui/routers/chat/routes.py
@@ -13,6 +13,7 @@ import tomlkit
 
 from src.chat.heart_flow.heartflow_manager import heartflow_manager
 from src.chat.message_receive.chat_manager import chat_manager as core_chat_manager
+from src.chat.replyer.replyer_manager import replyer_manager
 from src.common.database.database import get_db_session
 from src.common.database.database_model import (
     BehaviorAction,
@@ -1118,14 +1119,18 @@ def _delete_or_unlink_jargons(session: Any, session_id: str) -> Dict[str, int]:
     }
 
 
-def _release_deleted_chat_runtime(session_id: str) -> None:
-    """移除运行期缓存，避免定时保存把已删除聊天流重新写回数据库。"""
+async def _release_deleted_chat_runtime(session_id: str) -> None:
+    """释放已删除聊天流的运行期状态：移除内存缓存、停止心流运行时并失效 replyer 缓存。
 
-    core_chat_manager.sessions.pop(session_id, None)
-    heartflow_manager.heartflow_chat_list.pop(session_id, None)
+    避免定时保存把已删除聊天流重新写回数据库，同时防止运行时后台任务泄露。
+    """
+
+    core_chat_manager.release_session(session_id)
+    replyer_manager.invalidate_replyer(session_id)
+    await heartflow_manager.release_chat(session_id, reason="chat_deleted")
 
 
-def _delete_chat_session_scope(session_id: str) -> Dict[str, Any]:
+async def _delete_chat_session_scope(session_id: str) -> Dict[str, Any]:
     """删除聊天流及所有直接归属该 session_id 的数据库记录。"""
 
     with get_db_session() as session:
@@ -1169,7 +1174,7 @@ def _delete_chat_session_scope(session_id: str) -> Dict[str, Any]:
             total_deleted += deleted_count
             items.append({"key": key, "label": label, "count": deleted_count})
 
-    _release_deleted_chat_runtime(session_id)
+    await _release_deleted_chat_runtime(session_id)
     logger.warning(
         "已删除聊天流及关联数据: "
         f"session_id={session_id} total_deleted={total_deleted} items={items}"

--- a/src/webui/routers/chat/routes.py
+++ b/src/webui/routers/chat/routes.py
@@ -1127,7 +1127,11 @@ async def _release_deleted_chat_runtime(session_id: str) -> None:
 
     core_chat_manager.release_session(session_id)
     replyer_manager.invalidate_replyer(session_id)
-    await heartflow_manager.release_chat(session_id, reason="chat_deleted")
+    try:
+        await heartflow_manager.release_chat(session_id, reason="chat_deleted")
+    except Exception as exc:
+        # 数据库记录已删除；运行时停止失败仅记录，待后续释放/淘汰流程重试
+        logger.error(f"释放已删除聊天流 {session_id} 的心流运行时失败: {exc}", exc_info=True)
 
 
 async def _delete_chat_session_scope(session_id: str) -> Dict[str, Any]:

--- a/src/webui/routers/data_transfer.py
+++ b/src/webui/routers/data_transfer.py
@@ -423,8 +423,11 @@ def _run_import_job(job_id: str, archive_path: Path, enabled_parts: set[str]) ->
         job.error = str(exc)
         job.message = "导入失败"
     finally:
+        # 仅在删除成功后清空 file_path；失败时保留记录与路径，供 _evict_stale_jobs 后续重试
         try:
             archive_path.unlink(missing_ok=True)
+            if job.file_path == archive_path:
+                job.file_path = None
         except OSError as exc:
             logger.warning(f"清理导入临时文件失败: {archive_path}, error={exc}")
 
@@ -505,8 +508,20 @@ async def create_data_import(
 
     job = _new_job("import")
     upload_path = _TRANSFER_TEMP_DIR / f"{job.job_id}-upload.zip"
-    await _save_upload_file(file, upload_path)
-    await file.close()
+    # 上传前先把临时文件挂到任务上，确保任何失败路径都能被过期回收统一清理
+    job.file_path = upload_path
+    try:
+        try:
+            await _save_upload_file(file, upload_path)
+        finally:
+            await file.close()
+    except Exception as exc:
+        # 上传失败：任务置为终态并保留 file_path，交由 _evict_stale_jobs 统一回收重试
+        logger.warning(f"保存上传的数据包失败: {exc}")
+        job.error = str(exc)
+        job.message = "导入失败"
+        job.status = "failed"
+        raise HTTPException(status_code=500, detail="保存上传文件失败") from exc
 
     background_tasks.add_task(_run_import_job, job.job_id, upload_path, enabled_parts)
     return DataImportResponse(job_id=job.job_id, status=job.status)

--- a/src/webui/routers/data_transfer.py
+++ b/src/webui/routers/data_transfer.py
@@ -149,17 +149,23 @@ def _evict_stale_jobs() -> None:
     expired_count = sum(
         1 for finished_at, _ in finished_jobs if now - finished_at > _TRANSFER_JOB_RETENTION_SECONDS
     )
+    # 计算容量压力时把即将插入的新任务一并计入，保证插入后任务总数不超过上限
     removable_count = min(
-        max(expired_count, len(_jobs) - _TRANSFER_JOB_MAX_ENTRIES),
+        max(expired_count, len(_jobs) + 1 - _TRANSFER_JOB_MAX_ENTRIES),
         len(finished_jobs),
     )
     for _, job_id in finished_jobs[:removable_count]:
-        job = _jobs.pop(job_id, None)
-        if job is not None and job.file_path is not None:
+        job = _jobs.get(job_id)
+        if job is None:
+            continue
+        if job.file_path is not None:
             try:
                 job.file_path.unlink(missing_ok=True)
             except OSError as exc:
+                # 删除失败时保留任务记录及其 file_path，待后续回收时重试
                 logger.warning(f"清理数据迁移任务文件失败: {job.file_path}, error={exc}")
+                continue
+        _jobs.pop(job_id, None)
 
 
 def _new_job(kind: Literal["export", "import"]) -> _TransferJob:

--- a/src/webui/routers/data_transfer.py
+++ b/src/webui/routers/data_transfer.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 import json
 import shutil
 import tempfile
+import time
 import uuid
 import zipfile
 
@@ -34,6 +35,9 @@ _OPTIONAL_EXPORT_PARTS = ("plugins", "logs")
 _ALLOWED_IMPORT_PARTS = set(_EXPORT_DIRS)
 _TRANSFER_TEMP_DIR = Path(tempfile.gettempdir()) / "maibot_webui_transfer"
 _CHUNK_SIZE = 1024 * 1024
+_TERMINAL_JOB_STATUSES = {"completed", "failed", "cancelled"}
+_TRANSFER_JOB_RETENTION_SECONDS = 30 * 60
+_TRANSFER_JOB_MAX_ENTRIES = 64
 
 TransferJobStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
 
@@ -80,7 +84,7 @@ class _TransferJob:
     def __init__(self, job_id: str, kind: Literal["export", "import"]) -> None:
         self.job_id = job_id
         self.kind = kind
-        self.status: TransferJobStatus = "pending"
+        self._status: TransferJobStatus = "pending"
         self.progress = 0
         self.message = "等待处理"
         self.total_files = 0
@@ -92,6 +96,18 @@ class _TransferJob:
         self.manifest: dict[str, Any] | None = None
         self.error: str | None = None
         self.cancel_requested = False
+        self.finished_at: float | None = None
+
+    @property
+    def status(self) -> TransferJobStatus:
+        """任务状态；进入终态时记录时间戳，供过期回收使用。"""
+        return self._status
+
+    @status.setter
+    def status(self, value: TransferJobStatus) -> None:
+        self._status = value
+        if value in _TERMINAL_JOB_STATUSES and self.finished_at is None:
+            self.finished_at = time.monotonic()
 
     def to_response(self) -> DataTransferJobResponse:
         download_url = None
@@ -118,8 +134,37 @@ class _TransferJob:
 _jobs: dict[str, _TransferJob] = {}
 
 
+def _evict_stale_jobs() -> None:
+    """回收已结束且超过保留时长的任务记录，避免长期运行时任务字典无限累积。
+
+    超出容量上限时，即使未到期也会从最早的已结束任务开始回收；
+    进行中的任务（未进入终态）永远不会被回收。
+    """
+    now = time.monotonic()
+    finished_jobs = sorted(
+        (job.finished_at, job_id)
+        for job_id, job in _jobs.items()
+        if job.finished_at is not None
+    )
+    expired_count = sum(
+        1 for finished_at, _ in finished_jobs if now - finished_at > _TRANSFER_JOB_RETENTION_SECONDS
+    )
+    removable_count = min(
+        max(expired_count, len(_jobs) - _TRANSFER_JOB_MAX_ENTRIES),
+        len(finished_jobs),
+    )
+    for _, job_id in finished_jobs[:removable_count]:
+        job = _jobs.pop(job_id, None)
+        if job is not None and job.file_path is not None:
+            try:
+                job.file_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(f"清理数据迁移任务文件失败: {job.file_path}, error={exc}")
+
+
 def _new_job(kind: Literal["export", "import"]) -> _TransferJob:
     _TRANSFER_TEMP_DIR.mkdir(parents=True, exist_ok=True)
+    _evict_stale_jobs()
     job = _TransferJob(job_id=uuid.uuid4().hex, kind=kind)
     _jobs[job.job_id] = job
     return job

--- a/src/webui/routers/data_transfer.py
+++ b/src/webui/routers/data_transfer.py
@@ -171,6 +171,8 @@ def _evict_stale_jobs() -> None:
 def _new_job(kind: Literal["export", "import"]) -> _TransferJob:
     _TRANSFER_TEMP_DIR.mkdir(parents=True, exist_ok=True)
     _evict_stale_jobs()
+    if len(_jobs) >= _TRANSFER_JOB_MAX_ENTRIES:
+        raise HTTPException(status_code=429, detail="当前数据迁移任务并发数已达上限，请等待已有任务完成后重试")
     job = _TransferJob(job_id=uuid.uuid4().hex, kind=kind)
     _jobs[job.job_id] = job
     return job

--- a/src/webui/routers/emoji/support.py
+++ b/src/webui/routers/emoji/support.py
@@ -2,7 +2,8 @@ import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Dict, Set, Tuple
+from typing import Tuple
+from weakref import WeakValueDictionary
 
 from PIL import Image
 from sqlmodel import col, select
@@ -19,10 +20,11 @@ THUMBNAIL_QUALITY = 80
 EMOJI_REGISTERED_DIR = os.path.join("data", "emoji")
 EMOJI_DIR = EMOJI_REGISTERED_DIR
 
-_thumbnail_locks: Dict[str, threading.Lock] = {}
+# 弱值字典保存按哈希的生成锁：使用方在临界区内持有强引用，用完即被自动回收，避免按文件哈希无限累积。
+_thumbnail_locks: WeakValueDictionary = WeakValueDictionary()
 _locks_lock = threading.Lock()
 _thumbnail_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="thumbnail")
-_generating_thumbnails: Set[str] = set()
+_generating_thumbnails: set[str] = set()
 _generating_lock = threading.Lock()
 
 
@@ -36,17 +38,23 @@ def get_generating_lock() -> threading.Lock:
     return _generating_lock
 
 
-def get_generating_thumbnails() -> Set[str]:
+def get_generating_thumbnails() -> set[str]:
     """获取正在生成的缩略图哈希集合。"""
     return _generating_thumbnails
 
 
 def _get_thumbnail_lock(file_hash: str) -> threading.Lock:
-    """获取指定文件哈希的锁，用于防止并发生成同一缩略图。"""
+    """获取指定文件哈希的锁，用于防止并发生成同一缩略图。
+
+    锁条目在无人使用时自动回收：任何等待或持有该锁的线程都持有强引用，
+    因此不会出现两个线程拿到不同锁对象并发生成同一缩略图的情况。
+    """
     with _locks_lock:
-        if file_hash not in _thumbnail_locks:
-            _thumbnail_locks[file_hash] = threading.Lock()
-        return _thumbnail_locks[file_hash]
+        lock = _thumbnail_locks.get(file_hash)
+        if lock is None:
+            lock = threading.Lock()
+            _thumbnail_locks[file_hash] = lock
+        return lock
 
 
 def _background_generate_thumbnail(source_path: str, file_hash: str) -> None:

--- a/src/webui/routers/memory.py
+++ b/src/webui/routers/memory.py
@@ -10,6 +10,7 @@ import uuid
 
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Query, UploadFile
 from pydantic import BaseModel, Field
+from sqlalchemy import func
 from sqlmodel import col, select
 import tomlkit
 
@@ -396,22 +397,32 @@ def _prefetch_latest_messages_by_session(db_session: Any, session_ids: list[str]
     if not session_ids:
         return {}
 
-    statement = (
-        select(Messages)
+    # 用分组最大时间戳的子查询只取每个会话的最新一条消息，
+    # 避免把所有会话的全部消息行物化进内存（大库下单请求可达数百 MB）。
+    latest_per_session = (
+        select(col(Messages.session_id), func.max(col(Messages.timestamp)).label("max_timestamp"))
         .where(col(Messages.session_id).in_(session_ids))
-        .order_by(col(Messages.session_id).asc(), col(Messages.timestamp).desc())
+        .group_by(col(Messages.session_id))
+        .subquery()
+    )
+    statement = select(Messages).join(
+        latest_per_session,
+        (col(Messages.session_id) == col(latest_per_session.c.session_id))
+        & (col(Messages.timestamp) == col(latest_per_session.c.max_timestamp)),
     )
     latest: dict[str, dict[str, Any]] = {}
     for message in db_session.exec(statement).all():
         chat_id = str(message.session_id or "").strip()
-        if chat_id and chat_id not in latest:
-            latest[chat_id] = {
-                "group_id": message.group_id,
-                "group_name": message.group_name,
-                "user_id": message.user_id,
-                "user_cardname": message.user_cardname,
-                "user_nickname": message.user_nickname,
-            }
+        if not chat_id or chat_id in latest:
+            # 同一时间戳并列时跳过重复行。
+            continue
+        latest[chat_id] = {
+            "group_id": message.group_id,
+            "group_name": message.group_name,
+            "user_id": message.user_id,
+            "user_cardname": message.user_cardname,
+            "user_nickname": message.user_nickname,
+        }
     return latest
 
 
@@ -589,11 +600,11 @@ def _timeline_chat_from_session(chat_session: ChatSession) -> MemoryTimelineChat
     return MemoryTimelineChat(
         chat_id=chat_id,
         chat_name=_get_chat_name(chat_session, latest_messages),
-        platform=chat_session.platform,
-        group_id=chat_session.group_id,
-        user_id=chat_session.user_id,
-        account_id=chat_session.account_id,
-        is_group=bool(chat_session.group_id),
+        platform=getattr(chat_session, "platform", None),
+        group_id=getattr(chat_session, "group_id", None),
+        user_id=getattr(chat_session, "user_id", None),
+        account_id=getattr(chat_session, "account_id", None),
+        is_group=bool(getattr(chat_session, "group_id", None)),
     )
 
 
@@ -1368,6 +1379,11 @@ def _timeline_query_limit(limit: int, multiplier: int, minimum: int) -> Optional
     return max(limit * multiplier, minimum)
 
 
+# 时间界探测每类事件的目标条数：limit<=0 在收集器内表示"不限制"，
+# 全表扫描只为求 min/max 时间戳代价过高；改用有界采样估计时间范围。
+_TIMELINE_BOUND_PASS_LIMIT = 200
+
+
 def _append_limit(sql: str, limit: Optional[int]) -> str:
     if limit is None:
         return sql
@@ -1994,7 +2010,8 @@ async def _memory_timeline(
                 time_start=None,
                 time_end=None,
                 accepted_types=set(),
-                limit=0,
+                # 有界采样代替全表扫描：min/max 时间范围基于最近一批事件估计。
+                limit=_TIMELINE_BOUND_PASS_LIMIT,
             )
         )
     bound_events = _dedupe_timeline_events(bound_events)

--- a/src/webui/routers/memory.py
+++ b/src/webui/routers/memory.py
@@ -16,7 +16,7 @@ import tomlkit
 
 from src.A_memorix.host_service import a_memorix_host_service
 from src.A_memorix.runtime_registry import get_runtime_kernel
-from src.chat.message_receive.chat_manager import chat_manager as _chat_manager
+from src.chat.message_receive.chat_manager import BotChatSession, chat_manager as _chat_manager
 from src.common.database.database import get_db_session
 from src.common.database.database_model import ChatSession, Messages, PersonInfo
 from src.person_info.person_info import resolve_person_id_for_memory
@@ -597,14 +597,24 @@ def _timeline_chat_from_session(chat_session: ChatSession) -> MemoryTimelineChat
             latest_messages = _prefetch_latest_messages_by_session(session, [chat_id])
     except Exception:
         latest_messages = {}
+    if isinstance(chat_session, (ChatSession, BotChatSession)):
+        platform = chat_session.platform
+        group_id = chat_session.group_id
+        user_id = chat_session.user_id
+        account_id = chat_session.account_id
+    else:
+        platform = getattr(chat_session, "platform", None)
+        group_id = getattr(chat_session, "group_id", None)
+        user_id = getattr(chat_session, "user_id", None)
+        account_id = getattr(chat_session, "account_id", None)
     return MemoryTimelineChat(
         chat_id=chat_id,
         chat_name=_get_chat_name(chat_session, latest_messages),
-        platform=getattr(chat_session, "platform", None),
-        group_id=getattr(chat_session, "group_id", None),
-        user_id=getattr(chat_session, "user_id", None),
-        account_id=getattr(chat_session, "account_id", None),
-        is_group=bool(getattr(chat_session, "group_id", None)),
+        platform=platform,
+        group_id=group_id,
+        user_id=user_id,
+        account_id=account_id,
+        is_group=bool(group_id),
     )
 
 

--- a/src/webui/routers/plugin/management.py
+++ b/src/webui/routers/plugin/management.py
@@ -509,9 +509,9 @@ async def install_plugin(request: InstallPluginRequest, maibot_session: Optional
             elif manifest_plugin_id != plugin_id:
                 # 优先保留 manifest 中声明的真实 id，并重命名安装目录
                 manifest_plugin_id = validate_plugin_id(manifest_plugin_id)
-                new_target_path, _ = get_plugin_candidate_paths(manifest_plugin_id)
-                if new_target_path != target_path:
-                    if new_target_path.exists():
+                new_target_path, new_old_format_path = get_plugin_candidate_paths(manifest_plugin_id)
+                if new_target_path != target_path and new_old_format_path != target_path:
+                    if new_target_path.exists() or new_old_format_path.exists():
                         raise ValueError(f"目标目录已存在插件: {manifest_plugin_id}")
                     shutil.move(str(target_path), str(new_target_path))
                     target_path = new_target_path

--- a/src/webui/routers/plugin/management.py
+++ b/src/webui/routers/plugin/management.py
@@ -496,12 +496,27 @@ async def install_plugin(request: InstallPluginRequest, maibot_session: Optional
         try:
             with open(manifest_path, "r", encoding="utf-8") as file_obj:
                 manifest = json.load(file_obj)
-            for field in ["manifest_version", "id", "name", "version", "author"]:
+            for field in ["manifest_version", "name", "version", "author"]:
                 if field not in manifest:
                     raise ValueError(f"缺少必需字段: {field}")
             manifest_plugin_id = _read_manifest_plugin_id(manifest)
-            if manifest_plugin_id != plugin_id:
-                raise ValueError(f"插件 ID 不匹配：期望 {plugin_id}，实际 {manifest_plugin_id}")
+            if not manifest_plugin_id:
+                # 缺少 id 时回填请求中的 plugin_id
+                manifest["id"] = plugin_id
+                with open(manifest_path, "w", encoding="utf-8") as file_obj:
+                    json.dump(manifest, file_obj, ensure_ascii=False, indent=2)
+                manifest_plugin_id = plugin_id
+            elif manifest_plugin_id != plugin_id:
+                # 优先保留 manifest 中声明的真实 id，并重命名安装目录
+                manifest_plugin_id = validate_plugin_id(manifest_plugin_id)
+                new_target_path, _ = get_plugin_candidate_paths(manifest_plugin_id)
+                if new_target_path != target_path:
+                    if new_target_path.exists():
+                        raise ValueError(f"目标目录已存在插件: {manifest_plugin_id}")
+                    shutil.move(str(target_path), str(new_target_path))
+                    target_path = new_target_path
+                    manifest_path = resolve_plugin_file_path(target_path, "_manifest.json")
+                plugin_id = manifest_plugin_id
         except Exception as e:
             remove_tree(target_path)
             await update_progress(

--- a/src/webui/routers/plugin/management.py
+++ b/src/webui/routers/plugin/management.py
@@ -510,9 +510,11 @@ async def install_plugin(request: InstallPluginRequest, maibot_session: Optional
                 # 优先保留 manifest 中声明的真实 id，并重命名安装目录
                 manifest_plugin_id = validate_plugin_id(manifest_plugin_id)
                 new_target_path, new_old_format_path = get_plugin_candidate_paths(manifest_plugin_id)
-                if new_target_path != target_path and new_old_format_path != target_path:
-                    if new_target_path.exists() or new_old_format_path.exists():
+                # 检查两个候选路径中除当前临时克隆目录外的其他目录是否已存在
+                for candidate in (new_target_path, new_old_format_path):
+                    if candidate != target_path and candidate.exists():
                         raise ValueError(f"目标目录已存在插件: {manifest_plugin_id}")
+                if new_target_path != target_path:
                     shutil.move(str(target_path), str(new_target_path))
                     target_path = new_target_path
                     manifest_path = resolve_plugin_file_path(target_path, "_manifest.json")

--- a/src/webui/routers/plugin/progress.py
+++ b/src/webui/routers/plugin/progress.py
@@ -156,10 +156,11 @@ async def websocket_plugin_progress(websocket: WebSocket, token: Optional[str] =
                 break
 
     except WebSocketDisconnect:
-        active_connections.discard(websocket)
         logger.info(f"📡 插件进度 WebSocket 客户端已断开，当前连接数: {len(active_connections)}")
     except Exception as exc:
         logger.error(f"❌ WebSocket 错误: {exc}")
+    finally:
+        # 无论正常断开、异常还是任务被取消（CancelledError 不会被 except Exception 捕获），都必须移除连接引用
         active_connections.discard(websocket)
 
 

--- a/src/webui/routers/websocket/manager.py
+++ b/src/webui/routers/websocket/manager.py
@@ -13,6 +13,12 @@ from src.common.logger import get_logger
 logger = get_logger("webui.websocket")
 
 
+# 单个连接出站发送队列的上限。慢速或僵死的客户端（TCP 已连但不读取）会导致
+# 广播消息在其队列中无限积压，超过上限即判定连接异常并主动断开，
+# 由客户端重连后重新拉取状态。
+SEND_QUEUE_MAX_SIZE = 512
+
+
 @dataclass
 class WebSocketConnection:
     """统一 WebSocket 连接上下文。"""
@@ -21,7 +27,9 @@ class WebSocketConnection:
     websocket: WebSocket
     subscriptions: Set[str] = field(default_factory=set)
     chat_sessions: Dict[str, str] = field(default_factory=dict)
-    send_queue: "asyncio.Queue[Optional[Dict[str, Any]]]" = field(default_factory=asyncio.Queue)
+    send_queue: "asyncio.Queue[Optional[Dict[str, Any]]]" = field(
+        default_factory=lambda: asyncio.Queue(maxsize=SEND_QUEUE_MAX_SIZE)
+    )
     sender_task: Optional["asyncio.Task[None]"] = None
 
 
@@ -110,7 +118,14 @@ class UnifiedWebSocketManager:
         except Exception as exc:
             logger.debug(f"关闭统一 WebSocket 底层连接时出现异常: connection={connection_id}, error={exc}")
 
-        await connection.send_queue.put(None)
+        try:
+            # 队列可能已被慢速客户端填满，此时无法再投递退出哨兵，
+            # 直接取消发送协程以避免清理流程被阻塞。
+            connection.send_queue.put_nowait(None)
+        except asyncio.QueueFull:
+            if connection.sender_task is not None:
+                connection.sender_task.cancel()
+
         if connection.sender_task is not None:
             try:
                 await connection.sender_task
@@ -212,8 +227,28 @@ class UnifiedWebSocketManager:
             return False
         return self._build_subscription_key(domain, topic) in connection.subscriptions
 
+    def has_topic_subscribers(self, domain: str, topic: str) -> bool:
+        """判断是否存在任意连接订阅了指定主题。"""
+
+        subscription_key = self._build_subscription_key(domain, topic)
+        return any(
+            subscription_key in connection.subscriptions for connection in self.connections.values()
+        )
+
+    @staticmethod
+    def _try_put_nowait(connection: WebSocketConnection, message: Dict[str, Any]) -> bool:
+        """尝试立即把消息放入发送队列，队列已满时返回 ``False``。"""
+
+        try:
+            connection.send_queue.put_nowait(message)
+            return True
+        except asyncio.QueueFull:
+            return False
+
     async def enqueue(self, connection_id: str, message: Dict[str, Any]) -> None:
         """向指定连接的发送队列压入消息。
+
+        队列有界：投递失败说明客户端消费过慢，将调度断开该连接。
 
         Args:
             connection_id: 连接 ID。
@@ -230,23 +265,47 @@ class UnifiedWebSocketManager:
 
         current_loop = asyncio.get_running_loop()
         if target_loop is current_loop:
-            await connection.send_queue.put(message)
+            if not self._try_put_nowait(connection, message):
+                logger.warning(f"统一 WebSocket 发送队列已满，主动断开慢速连接: connection={connection_id}")
+                await self.disconnect(connection_id)
             return
 
         # WebUI 运行在独立线程事件循环中，跨 loop 投递必须回到连接所属 loop 执行。
+        async def _put_on_target_loop() -> bool:
+            return self._try_put_nowait(connection, message)
+
         try:
-            future = asyncio.run_coroutine_threadsafe(connection.send_queue.put(message), target_loop)
+            future = asyncio.run_coroutine_threadsafe(_put_on_target_loop(), target_loop)
         except RuntimeError as exc:
             logger.debug(f"统一 WebSocket 跨线程投递失败: connection={connection_id}, error={exc}")
             return
 
         try:
-            await asyncio.wrap_future(future)
+            delivered = await asyncio.wrap_future(future)
         except asyncio.CancelledError:
             future.cancel()
             raise
         except Exception as exc:
             logger.debug(f"统一 WebSocket 等待跨线程投递时出现异常: connection={connection_id}, error={exc}")
+            return
+
+        if not delivered:
+            logger.warning(f"统一 WebSocket 发送队列已满，主动断开慢速连接: connection={connection_id}")
+            # 断开清理必须回到连接所属的事件循环执行。
+            try:
+                disconnect_future = asyncio.run_coroutine_threadsafe(self.disconnect(connection_id), target_loop)
+            except RuntimeError as exc:
+                logger.debug(f"统一 WebSocket 调度断开慢速连接失败: connection={connection_id}, error={exc}")
+                return
+            disconnect_future.add_done_callback(
+                lambda future: (
+                    None
+                    if future.exception() is None
+                    else logger.debug(
+                        f"统一 WebSocket 断开慢速连接时出现异常: connection={connection_id}, error={future.exception()}"
+                    )
+                )
+            )
 
     async def send_response(
         self,


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）: 无
7. 请简要说明本次更新的内容和目的：
本次提交集中优化了心流生命周期、锁与租约管理、全仓内存与资源泄露控制，并补齐了存量测试用例：

### 1. 心流生命周期与锁优化
- **弱值字典锁管理**：在心流管理等模块引入 `WeakValueDictionary` 管理会话锁与运行时实例，防止死会话锁常驻内存。
- **租约与排空时限**：为心流借用增加超限淘汰与排空超时机制；确保 `borrow_chat` 在协程被取消（`CancelledError`）路径下必定释放使用租约，杜绝死锁与租约悬挂。
- **资源释放与竞态修复**：修复会话销毁与重载链路中的状态残留与并发竞态问题。

### 2. 全仓内存泄露与资源控制
- **LLM 流式连接泄漏**：修复 `openai_client` / `gemini_client` 在外部打断或解析异常时未显式关闭底层 stream（SSE 连接滞留）的问题。
- **无界容器修剪与淘汰**：
  - `maisaka/reply_effect`：终态且无活跃引用的回复效果记录在评审完成后自动移除。
  - `maisaka/runtime`：心流 `history_loop` 改为有界 `deque(maxlen=200)`。
  - `chat_manager`：增加 24h 不活跃会话与过期消息的定期内存淘汰。
  - `A_memorix` 检索调优：增加已完成任务记录上限（50 条）与修剪机制；画像刷新循环自动剔除过期人物时间戳。
  - `embedding` 向量缓存、`llm_cache_stats` 统计键、`rate_limiter` IP 表均增加容量上限与淘汰机制。
- **IPC / RPC 资源清理**：修复 `rpc_server` / `rpc_client` 在调用方被取消时 pending 请求表条目残留问题。
- **图片与表情包内存优化**：
  - `emoji_manager` 启动加载增加 SQL 层过滤，避免全表物化聊天图片；注册成功后及时释放常驻的 `image_bytes`。
  - 插件 RPC 消息查询增加条数上限保护（默认 100，上限 500），防止 `limit=0` 穿透触发全库物化。
- **磁盘无界增长控制**：
  - `runner_rpc_debug.jsonl` 增加单代 16MB 自动轮转（保留一代 `.1`）。
  - `replyer_action_*.json` 每次写入后自动维护，保留最近 200 个文件。
- **WebUI 内存尖峰优化**：
  - `memory.py` 预取最新消息改为按会话最大时间戳子查询；时间界探测改为有界采样。

### 3. 测试用例与兼容性修复
- 修复插件安装时 manifest 真实 ID 继承与重命名逻辑。
- 修复 `test_startup_bindings`、`test_jargon_routes`、`test_memory_routes`、`test_model_routes`、`test_plugin_management_routes`、`test_lpmm_convert` 等存量测试断言与 mock 桩。
- 全仓测试套件达成 **1416 passed, 0 failed, 4 skipped (100%)**，`ruff check` 0 警告 0 报错。

# 其他信息
- **关联 Issue**：
- **截图/GIF**：
- **附加信息**: 涉及 `src/A_memorix` 的改动均为最小化防御性补丁（向量缓存上限、调优任务修剪与时间戳清理），严格遵守 A_memorix 修改策略。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件安装支持缺少清单 ID，并自动补全。
  * 插件消息查询新增默认值与最大数量限制。
  * 聊天会话支持安全释放及长期不活跃会话清理。
  * WebSocket 消息队列增加容量保护。
  * 数据导入任务支持过期清理、容量限制及失败状态反馈。
  * 记忆导入支持向量与图数据存储，并提供 metadata-only 回退。

* **问题修复**
  * 改善聊天运行时、模型连接及流式响应的生命周期管理。
  * 限制缓存、任务记录、历史状态和临时文件增长。
  * 优化日志连接、插件事件及任务取消时的资源清理。
  * 修复时间线查询、图片消息展示及插件安装处理问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->