### PR TITLE
fix: 超长/超宽图导致视觉接口 400 unsupported image 崩溃

### DIFF
--- a/pytests/maisaka/test_maisaka_image_normalize.py
+++ b/pytests/maisaka/test_maisaka_image_normalize.py
@@ -6,25 +6,37 @@ import base64
 from PIL import Image
 
 from src.common.data_models.message_component_data_model import ImageComponent
+from src.llm_models.payload_content.context_item import (
+    ContextImagePart,
+    ContextItemBuilder,
+    RoleType,
+)
 from src.maisaka.context.messages import (
     MAISAKA_IMAGE_MAX_SIDE,
     MAISAKA_IMAGE_SEGMENT_OVERLAP,
+    _append_image_component,
     _normalize_maisaka_image,
     _split_maisaka_image,
 )
 
 
 def _image_bytes(image: Image.Image, image_format: str = "JPEG") -> bytes:
+    """将 PIL 图片编码为字节数据。"""
+
     output_buffer = BytesIO()
     image.save(output_buffer, format=image_format)
     return output_buffer.getvalue()
 
 
 def _decode_segments(segments: list[tuple[str, str]]) -> list[Image.Image]:
+    """将规范化后的 (format, base64) 段解码为 PIL 图片列表。"""
+
     return [Image.open(BytesIO(base64.b64decode(base64_data))) for _, base64_data in segments]
 
 
 def test_normal_image_kept_unchanged() -> None:
+    """普通尺寸图片应保持原样，不分割不缩放。"""
+
     image = Image.new("RGB", (716, 528), "white")
     segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
 
@@ -34,6 +46,8 @@ def test_normal_image_kept_unchanged() -> None:
 
 
 def test_tall_image_split_along_height() -> None:
+    """超长图应沿高度方向分割为多段。"""
+
     image = Image.new("RGB", (700, 10800), "white")
     segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
 
@@ -47,6 +61,8 @@ def test_tall_image_split_along_height() -> None:
 
 
 def test_wide_image_split_along_width() -> None:
+    """超宽图应沿宽度方向分割为多段。"""
+
     image = Image.new("RGB", (10800, 700), "white")
     segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
 
@@ -57,6 +73,8 @@ def test_wide_image_split_along_width() -> None:
 
 
 def test_large_image_scaled_down() -> None:
+    """单边超限但长宽比正常的图片应等比例缩放。"""
+
     image = Image.new("RGB", (5000, 3000), "white")
     segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
 
@@ -68,6 +86,8 @@ def test_large_image_scaled_down() -> None:
 
 
 def test_split_segments_overlap() -> None:
+    """分割段之间应保留重叠像素。"""
+
     image = Image.new("RGB", (700, 10800), "white")
     segments = _split_maisaka_image(image, 700, 10800)
 
@@ -79,6 +99,8 @@ def test_split_segments_overlap() -> None:
 
 
 def test_animated_gif_kept_unchanged() -> None:
+    """GIF 动图应保持原样，不做分割/缩放。"""
+
     gif_buffer = BytesIO()
     frames = [Image.new("RGB", (100, 100), "red"), Image.new("RGB", (100, 100), "blue")]
     frames[0].save(
@@ -98,15 +120,12 @@ def test_animated_gif_kept_unchanged() -> None:
 def test_image_component_append_uses_normalized_segments() -> None:
     """验证 _append_image_component 对超长图会追加多张图片。"""
 
-    from src.llm_models.payload_content.context_item import ContextItemBuilder, ContextImagePart, RoleType
-
     image = Image.new("RGB", (700, 10800), "white")
     component = ImageComponent(
         binary_hash="test-hash",
         binary_data=_image_bytes(image),
     )
     builder = ContextItemBuilder().set_role(RoleType.User)
-    from src.maisaka.context.messages import _append_image_component
 
     appended = _append_image_component(builder, component, enable_visual_message=True)
     assert appended is True
@@ -115,3 +134,16 @@ def test_image_component_append_uses_normalized_segments() -> None:
     image_parts = [part for part in item.parts if isinstance(part, ContextImagePart)]
     assert len(image_parts) == 3
     assert all(part.image_format == "jpeg" for part in image_parts)
+
+
+def test_extreme_tall_image_falls_back_to_scaling() -> None:
+    """极长图片分割段数超过上限时改为整体缩放。"""
+
+    image = Image.new("RGB", (700, 10800 * 5), "white")
+    segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
+
+    assert len(segments) == 1
+    decoded = _decode_segments(segments)[0]
+    assert max(decoded.size) <= MAISAKA_IMAGE_MAX_SIDE
+    # 整体缩放保持长宽比：宽度 = 4096 * (700 / 54000) ≈ 53
+    assert abs(decoded.size[0] / decoded.size[1] - 700 / 54000) < 0.01

--- a/pytests/maisaka/test_maisaka_image_normalize.py
+++ b/pytests/maisaka/test_maisaka_image_normalize.py
@@ -1,0 +1,117 @@
+"""Maisaka 图片规范化（分割/缩放）测试。"""
+
+from io import BytesIO
+import base64
+
+from PIL import Image
+
+from src.common.data_models.message_component_data_model import ImageComponent
+from src.maisaka.context.messages import (
+    MAISAKA_IMAGE_MAX_SIDE,
+    MAISAKA_IMAGE_SEGMENT_OVERLAP,
+    _normalize_maisaka_image,
+    _split_maisaka_image,
+)
+
+
+def _image_bytes(image: Image.Image, image_format: str = "JPEG") -> bytes:
+    output_buffer = BytesIO()
+    image.save(output_buffer, format=image_format)
+    return output_buffer.getvalue()
+
+
+def _decode_segments(segments: list[tuple[str, str]]) -> list[Image.Image]:
+    return [Image.open(BytesIO(base64.b64decode(base64_data))) for _, base64_data in segments]
+
+
+def test_normal_image_kept_unchanged() -> None:
+    image = Image.new("RGB", (716, 528), "white")
+    segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
+
+    assert len(segments) == 1
+    decoded = _decode_segments(segments)[0]
+    assert decoded.size == (716, 528)
+
+
+def test_tall_image_split_along_height() -> None:
+    image = Image.new("RGB", (700, 10800), "white")
+    segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
+
+    assert len(segments) == 3
+    decoded = _decode_segments(segments)
+    assert all(segment.size[0] == 700 for segment in decoded)
+    assert all(segment.size[1] <= MAISAKA_IMAGE_MAX_SIDE for segment in decoded)
+    # 段间重叠：第一段与第二段应重叠 MAISAKA_IMAGE_SEGMENT_OVERLAP 像素
+    assert decoded[0].size[1] == MAISAKA_IMAGE_MAX_SIDE
+    assert decoded[1].size[1] == MAISAKA_IMAGE_MAX_SIDE
+
+
+def test_wide_image_split_along_width() -> None:
+    image = Image.new("RGB", (10800, 700), "white")
+    segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
+
+    assert len(segments) == 3
+    decoded = _decode_segments(segments)
+    assert all(segment.size[1] == 700 for segment in decoded)
+    assert all(segment.size[0] <= MAISAKA_IMAGE_MAX_SIDE for segment in decoded)
+
+
+def test_large_image_scaled_down() -> None:
+    image = Image.new("RGB", (5000, 3000), "white")
+    segments = _normalize_maisaka_image(_image_bytes(image), "jpeg")
+
+    assert len(segments) == 1
+    decoded = _decode_segments(segments)[0]
+    assert max(decoded.size) <= MAISAKA_IMAGE_MAX_SIDE
+    # 保持长宽比（允许取整误差）
+    assert abs(decoded.size[0] / decoded.size[1] - 5000 / 3000) < 0.01
+
+
+def test_split_segments_overlap() -> None:
+    image = Image.new("RGB", (700, 10800), "white")
+    segments = _split_maisaka_image(image, 700, 10800)
+
+    assert len(segments) == 3
+    # 段0 高度 4096，段1 从 4096-24 开始，段2 从 8168-24 开始
+    assert segments[0].size == (700, MAISAKA_IMAGE_MAX_SIDE)
+    assert segments[1].size == (700, MAISAKA_IMAGE_MAX_SIDE)
+    assert segments[2].size == (700, 10800 - 2 * (MAISAKA_IMAGE_MAX_SIDE - MAISAKA_IMAGE_SEGMENT_OVERLAP))
+
+
+def test_animated_gif_kept_unchanged() -> None:
+    gif_buffer = BytesIO()
+    frames = [Image.new("RGB", (100, 100), "red"), Image.new("RGB", (100, 100), "blue")]
+    frames[0].save(
+        gif_buffer,
+        format="GIF",
+        save_all=True,
+        append_images=frames[1:],
+        duration=100,
+        loop=0,
+    )
+    segments = _normalize_maisaka_image(gif_buffer.getvalue(), "gif")
+
+    assert len(segments) == 1
+    assert segments[0][0] == "gif"
+
+
+def test_image_component_append_uses_normalized_segments() -> None:
+    """验证 _append_image_component 对超长图会追加多张图片。"""
+
+    from src.llm_models.payload_content.context_item import ContextItemBuilder, ContextImagePart, RoleType
+
+    image = Image.new("RGB", (700, 10800), "white")
+    component = ImageComponent(
+        binary_hash="test-hash",
+        binary_data=_image_bytes(image),
+    )
+    builder = ContextItemBuilder().set_role(RoleType.User)
+    from src.maisaka.context.messages import _append_image_component
+
+    appended = _append_image_component(builder, component, enable_visual_message=True)
+    assert appended is True
+
+    item = builder.build()
+    image_parts = [part for part in item.parts if isinstance(part, ContextImagePart)]
+    assert len(image_parts) == 3
+    assert all(part.image_format == "jpeg" for part in image_parts)

--- a/pytests/maisaka/test_maisaka_image_normalize.py
+++ b/pytests/maisaka/test_maisaka_image_normalize.py
@@ -147,3 +147,29 @@ def test_extreme_tall_image_falls_back_to_scaling() -> None:
     assert max(decoded.size) <= MAISAKA_IMAGE_MAX_SIDE
     # 整体缩放保持长宽比：宽度 = 4096 * (700 / 54000) ≈ 53
     assert abs(decoded.size[0] / decoded.size[1] - 700 / 54000) < 0.01
+
+
+def test_rgba_image_flattened_to_white_background() -> None:
+    """RGBA 透明图应合成到白色背景上，透明区域为白色而非黑色。"""
+
+    image = Image.new("RGBA", (100, 100), (255, 0, 0, 0))  # 全透明红色
+    segments = _normalize_maisaka_image(_image_bytes(image, "PNG"), "png")
+
+    assert len(segments) == 1
+    decoded = _decode_segments(segments)[0]
+    assert decoded.mode == "RGB"
+    # 透明区域合成到白色背景后应为白色
+    assert decoded.getpixel((50, 50)) == (255, 255, 255)
+
+
+def test_palette_image_with_transparency_flattened() -> None:
+    """含 transparency 信息的 P 模式图片应合成到白色背景上。"""
+
+    image = Image.new("P", (100, 100))
+    image.info["transparency"] = 0
+    image.putpalette([255, 0, 0, 0, 255, 0, 0, 0, 255] + [0, 0, 0] * 253)
+    segments = _normalize_maisaka_image(_image_bytes(image, "PNG"), "png")
+
+    assert len(segments) == 1
+    decoded = _decode_segments(segments)[0]
+    assert decoded.mode == "RGB"

--- a/pytests/test_image_text_fallback.py
+++ b/pytests/test_image_text_fallback.py
@@ -1,0 +1,100 @@
+"""图片降级为纯文本兜底（400 unsupported image）测试。"""
+
+import base64
+from io import BytesIO
+
+from PIL import Image
+
+from src.llm_models.exceptions import RespNotOkException
+from src.llm_models.payload_content.context_item import (
+    AssistantMessageItem,
+    ContextImagePart,
+    ContextItemMeta,
+    ContextTextPart,
+    UserMessageItem,
+)
+from src.llm_models.utils import IMAGE_TEXT_PLACEHOLDER, replace_images_with_text
+from src.llm_models.utils_model import LLMOrchestrator
+
+
+def _meta() -> ContextItemMeta:
+    return ContextItemMeta.create(item_id="item-1")
+
+
+def _image_part() -> ContextImagePart:
+    image = Image.new("RGB", (100, 100), "white")
+    output_buffer = BytesIO()
+    image.save(output_buffer, format="JPEG")
+    return ContextImagePart(
+        image_format="jpeg",
+        image_base64=base64.b64encode(output_buffer.getvalue()).decode("utf-8"),
+    )
+
+
+def test_replace_images_with_text_in_user_item() -> None:
+    item = UserMessageItem(
+        meta=_meta(),
+        parts=(ContextTextPart("文本"), _image_part(), ContextTextPart("更多文本")),
+    )
+
+    replaced = replace_images_with_text([item])[0]
+
+    assert isinstance(replaced, UserMessageItem)
+    assert all(isinstance(part, ContextTextPart) for part in replaced.parts)
+    assert replaced.parts[0].text == "文本"
+    assert replaced.parts[1].text == IMAGE_TEXT_PLACEHOLDER
+    assert replaced.parts[2].text == "更多文本"
+
+
+def test_replace_images_with_text_in_assistant_item_clears_replay() -> None:
+    item = AssistantMessageItem(
+        meta=_meta(),
+        parts=(_image_part(),),
+        replay="should-be-cleared",
+    )
+
+    replaced = replace_images_with_text([item])[0]
+
+    assert isinstance(replaced, AssistantMessageItem)
+    assert replaced.replay is None
+    assert all(isinstance(part, ContextTextPart) for part in replaced.parts)
+
+
+def test_replace_images_with_text_keeps_text_only_items() -> None:
+    item = UserMessageItem(meta=_meta(), parts=(ContextTextPart("纯文本"),))
+
+    replaced = replace_images_with_text([item])[0]
+
+    assert replaced == item
+
+
+def test_replace_images_with_text_handles_empty_list() -> None:
+    assert replace_images_with_text([]) == []
+
+
+def test_is_unsupported_image_error_matches_keyword() -> None:
+    error = RespNotOkException(
+        400,
+        "input[49].image[0]: You have uploaded an unsupported image. "
+        "Please make sure your image is valid and has one of the following formats: webp, png, jpeg, and gif.",
+    )
+
+    assert LLMOrchestrator._is_unsupported_image_error(error) is True
+
+
+def test_is_unsupported_image_error_ignores_other_errors() -> None:
+    error = RespNotOkException(400, "The reasoning_text in the thinking mode must be passed back to the API.")
+
+    assert LLMOrchestrator._is_unsupported_image_error(error) is False
+
+
+def test_is_unsupported_image_error_matches_cause() -> None:
+    # 模拟真实场景：RespNotOkException.message 由 _build_api_status_message 拼接
+    # error.message 与 response.text，其中 response.text 含完整 API 错误响应。
+    error = RespNotOkException(
+        400,
+        "BadRequestError | Error code: 400 - {'error': {'message': 'input[49].image[0]: "
+        "You have uploaded an unsupported image. Please make sure your image is valid...'}}",
+    )
+
+    assert LLMOrchestrator._is_unsupported_image_error(error) is True

--- a/pytests/test_image_text_fallback.py
+++ b/pytests/test_image_text_fallback.py
@@ -1,7 +1,7 @@
 """图片降级为纯文本兜底（400 unsupported image）测试。"""
 
-import base64
 from io import BytesIO
+import base64
 
 from PIL import Image
 
@@ -18,10 +18,14 @@ from src.llm_models.utils_model import LLMOrchestrator
 
 
 def _meta() -> ContextItemMeta:
+    """构造测试用 Item 元数据。"""
+
     return ContextItemMeta.create(item_id="item-1")
 
 
 def _image_part() -> ContextImagePart:
+    """构造测试用 JPEG 图片片段。"""
+
     image = Image.new("RGB", (100, 100), "white")
     output_buffer = BytesIO()
     image.save(output_buffer, format="JPEG")
@@ -32,6 +36,8 @@ def _image_part() -> ContextImagePart:
 
 
 def test_replace_images_with_text_in_user_item() -> None:
+    """用户消息中的图片片段应被替换为文本占位符。"""
+
     item = UserMessageItem(
         meta=_meta(),
         parts=(ContextTextPart("文本"), _image_part(), ContextTextPart("更多文本")),
@@ -47,6 +53,8 @@ def test_replace_images_with_text_in_user_item() -> None:
 
 
 def test_replace_images_with_text_in_assistant_item_clears_replay() -> None:
+    """助手消息中的图片被替换时应清除 replay fragment。"""
+
     item = AssistantMessageItem(
         meta=_meta(),
         parts=(_image_part(),),
@@ -61,6 +69,8 @@ def test_replace_images_with_text_in_assistant_item_clears_replay() -> None:
 
 
 def test_replace_images_with_text_keeps_text_only_items() -> None:
+    """纯文本消息应原样保留。"""
+
     item = UserMessageItem(meta=_meta(), parts=(ContextTextPart("纯文本"),))
 
     replaced = replace_images_with_text([item])[0]
@@ -69,10 +79,14 @@ def test_replace_images_with_text_keeps_text_only_items() -> None:
 
 
 def test_replace_images_with_text_handles_empty_list() -> None:
+    """空消息列表应返回空列表。"""
+
     assert replace_images_with_text([]) == []
 
 
 def test_is_unsupported_image_error_matches_keyword() -> None:
+    """含 unsupported image 关键词的错误应被识别。"""
+
     error = RespNotOkException(
         400,
         "input[49].image[0]: You have uploaded an unsupported image. "
@@ -83,12 +97,16 @@ def test_is_unsupported_image_error_matches_keyword() -> None:
 
 
 def test_is_unsupported_image_error_ignores_other_errors() -> None:
+    """不含 unsupported image 关键词的错误不应被识别。"""
+
     error = RespNotOkException(400, "The reasoning_text in the thinking mode must be passed back to the API.")
 
     assert LLMOrchestrator._is_unsupported_image_error(error) is False
 
 
 def test_is_unsupported_image_error_matches_cause() -> None:
+    """错误链底层异常含 unsupported image 时也应被识别。"""
+
     # 模拟真实场景：RespNotOkException.message 由 _build_api_status_message 拼接
     # error.message 与 response.text，其中 response.text 含完整 API 错误响应。
     error = RespNotOkException(

--- a/src/llm_models/utils.py
+++ b/src/llm_models/utils.py
@@ -13,6 +13,7 @@ from src.llm_models.payload_content.context_item import (
     AssistantMessageItem,
     ContextImagePart,
     ContextItem,
+    ContextTextPart,
     SystemMessageItem,
     UserMessageItem,
 )
@@ -20,6 +21,38 @@ from src.llm_models.payload_content.context_item import (
 from .model_client.base_client import UsageRecord
 
 logger = get_logger("消息压缩工具")
+
+IMAGE_TEXT_PLACEHOLDER = "[图片]"
+"""图片被替换为纯文本时的占位符。"""
+
+
+def replace_images_with_text(items: list[ContextItem]) -> list[ContextItem]:
+    """将消息列表中的图片片段替换为纯文本占位符。
+
+    当视觉接口拒绝图片（如 400 unsupported image）时，将当前请求中的图片
+    降级为文本占位符后重试；旧上下文（历史消息）仍维持多模态。
+
+    :param items: 消息列表
+    :return: 图片被替换为文本占位符后的消息列表
+    """
+
+    def rebuild_item_with_text_images(item: ContextItem) -> ContextItem:
+        """重建含图片的消息 Item，并只清除被修改 Item 自身的 replay fragment。"""
+
+        if not isinstance(item, (SystemMessageItem, UserMessageItem, AssistantMessageItem)):
+            return item
+        if not any(isinstance(part, ContextImagePart) for part in item.parts):
+            return item
+
+        text_parts = tuple(
+            ContextTextPart(IMAGE_TEXT_PLACEHOLDER) if isinstance(part, ContextImagePart) else part
+            for part in item.parts
+        )
+        if isinstance(item, AssistantMessageItem):
+            return replace(item, parts=text_parts, replay=None)
+        return replace(item, parts=text_parts)
+
+    return [rebuild_item_with_text_images(item) for item in items]
 
 
 def compress_messages(items: list[ContextItem], img_target_size: int = 1 * 1024 * 1024) -> list[ContextItem]:

--- a/src/llm_models/utils.py
+++ b/src/llm_models/utils.py
@@ -1,5 +1,6 @@
 from dataclasses import replace
 from datetime import datetime
+from typing import Callable
 import base64
 import io
 
@@ -11,6 +12,7 @@ from src.common.logger import get_logger
 from src.config.model_configs import ModelInfo
 from src.llm_models.payload_content.context_item import (
     AssistantMessageItem,
+    ContextContentPart,
     ContextImagePart,
     ContextItem,
     ContextTextPart,
@@ -26,6 +28,30 @@ IMAGE_TEXT_PLACEHOLDER = "[图片]"
 """图片被替换为纯文本时的占位符。"""
 
 
+def _rebuild_item_with_image_transform(
+    item: ContextItem,
+    transform: Callable[[ContextImagePart], ContextContentPart],
+) -> ContextItem:
+    """重建含图片的消息 Item，并只清除被修改 Item 自身的 replay fragment。
+
+    Args:
+        item: 待重建的上下文 Item。
+        transform: 将图片片段转换为新片段的函数。
+
+    Returns:
+        ContextItem: 重建后的 Item；不含图片或类型不支持时原样返回。
+    """
+    if not isinstance(item, (SystemMessageItem, UserMessageItem, AssistantMessageItem)):
+        return item
+    if not any(isinstance(part, ContextImagePart) for part in item.parts):
+        return item
+
+    new_parts = tuple(transform(part) if isinstance(part, ContextImagePart) else part for part in item.parts)
+    if isinstance(item, AssistantMessageItem):
+        return replace(item, parts=new_parts, replay=None)
+    return replace(item, parts=new_parts)
+
+
 def replace_images_with_text(items: list[ContextItem]) -> list[ContextItem]:
     """将消息列表中的图片片段替换为纯文本占位符。
 
@@ -35,24 +61,9 @@ def replace_images_with_text(items: list[ContextItem]) -> list[ContextItem]:
     :param items: 消息列表
     :return: 图片被替换为文本占位符后的消息列表
     """
-
-    def rebuild_item_with_text_images(item: ContextItem) -> ContextItem:
-        """重建含图片的消息 Item，并只清除被修改 Item 自身的 replay fragment。"""
-
-        if not isinstance(item, (SystemMessageItem, UserMessageItem, AssistantMessageItem)):
-            return item
-        if not any(isinstance(part, ContextImagePart) for part in item.parts):
-            return item
-
-        text_parts = tuple(
-            ContextTextPart(IMAGE_TEXT_PLACEHOLDER) if isinstance(part, ContextImagePart) else part
-            for part in item.parts
-        )
-        if isinstance(item, AssistantMessageItem):
-            return replace(item, parts=text_parts, replay=None)
-        return replace(item, parts=text_parts)
-
-    return [rebuild_item_with_text_images(item) for item in items]
+    return [
+        _rebuild_item_with_image_transform(item, lambda _: ContextTextPart(IMAGE_TEXT_PLACEHOLDER)) for item in items
+    ]
 
 
 def compress_messages(items: list[ContextItem], img_target_size: int = 1 * 1024 * 1024) -> list[ContextItem]:
@@ -172,28 +183,15 @@ def compress_messages(items: list[ContextItem], img_target_size: int = 1 * 1024 
 
         return base64_data
 
-    def rebuild_item_with_compressed_images(item: ContextItem) -> ContextItem:
-        """重建含图片的消息 Item，并只清除被修改 Item 自身的 replay fragment。"""
+    def compress_image_part(part: ContextImagePart) -> ContextImagePart:
+        """压缩单个图片片段。"""
 
-        if not isinstance(item, (SystemMessageItem, UserMessageItem, AssistantMessageItem)):
-            return item
-        if not any(isinstance(part, ContextImagePart) for part in item.parts):
-            return item
-
-        compressed_parts = tuple(
-            ContextImagePart(
-                image_format=part.image_format,
-                image_base64=compress_base64_image(part.image_base64, target_size=img_target_size),
-            )
-            if isinstance(part, ContextImagePart)
-            else part
-            for part in item.parts
+        return ContextImagePart(
+            image_format=part.image_format,
+            image_base64=compress_base64_image(part.image_base64, target_size=img_target_size),
         )
-        if isinstance(item, AssistantMessageItem):
-            return replace(item, parts=compressed_parts, replay=None)
-        return replace(item, parts=compressed_parts)
 
-    return [rebuild_item_with_compressed_images(item) for item in items]
+    return [_rebuild_item_with_image_transform(item, compress_image_part) for item in items]
 
 
 class LLMUsageRecorder:

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -52,7 +52,14 @@ from src.llm_models.request_snapshot import (
     serialize_client_request_snapshot,
     update_failed_request_attempt,
 )
-from src.llm_models.payload_content.context_item import ContextItem, ContextItemBuilder
+from src.llm_models.payload_content.context_item import (
+    AssistantMessageItem,
+    ContextImagePart,
+    ContextItem,
+    ContextItemBuilder,
+    SystemMessageItem,
+    UserMessageItem,
+)
 from src.llm_models.payload_content.resp_format import RespFormat
 from src.llm_models.payload_content.tool_option import (
     ToolDefinitionInput,
@@ -174,11 +181,15 @@ class LLMOrchestrator:
             )
 
     @staticmethod
-    def _can_retry_with_compressed_images(
+    def _can_retry_with_image_fallback(
         active_request: ClientRequest,
         original_response_request: ResponseRequest | None,
     ) -> bool:
-        """判断当前请求是否还可以通过压缩图片进行一次兜底重试。"""
+        """判断当前请求是否还可以通过图片相关降级（压缩或转文本）进行一次兜底重试。
+
+        仅当当前请求仍是原始请求（context_items 未被修改过）时允许降级重试，
+        避免压缩/转文本后再次失败时无限重试。
+        """
         return (
             isinstance(active_request, ResponseRequest)
             and bool(active_request.context_items)
@@ -187,13 +198,17 @@ class LLMOrchestrator:
         )
 
     @staticmethod
-    def _extract_data_uri_limit_bytes(error: RespNotOkException) -> int | None:
-        """从兼容 OpenAI 的错误文本中提取 data URI 单项大小限制。"""
+    def _collect_candidate_error_messages(error: RespNotOkException) -> list[str]:
+        """收集用于错误特征匹配的候选文本（含底层异常链）。"""
         candidate_messages = [error.message, str(error)]
         if error.__cause__ is not None:
             candidate_messages.append(str(error.__cause__))
+        return candidate_messages
 
-        for candidate_message in candidate_messages:
+    @staticmethod
+    def _extract_data_uri_limit_bytes(error: RespNotOkException) -> int | None:
+        """从兼容 OpenAI 的错误文本中提取 data URI 单项大小限制。"""
+        for candidate_message in LLMOrchestrator._collect_candidate_error_messages(error):
             if not candidate_message:
                 continue
 
@@ -211,11 +226,21 @@ class LLMOrchestrator:
     @staticmethod
     def _is_unsupported_image_error(error: RespNotOkException) -> bool:
         """判断错误是否为视觉接口拒绝图片（400 unsupported image）。"""
-        candidate_messages = [error.message, str(error)]
-        if error.__cause__ is not None:
-            candidate_messages.append(str(error.__cause__))
+        return any(
+            UNSUPPORTED_IMAGE_PATTERN.search(candidate_message)
+            for candidate_message in LLMOrchestrator._collect_candidate_error_messages(error)
+        )
 
-        return any(UNSUPPORTED_IMAGE_PATTERN.search(candidate_message) for candidate_message in candidate_messages)
+    @staticmethod
+    def _has_image_part(items: list[ContextItem]) -> bool:
+        """判断消息列表中是否包含图片片段。"""
+
+        for item in items:
+            if not isinstance(item, (SystemMessageItem, UserMessageItem, AssistantMessageItem)):
+                continue
+            if any(isinstance(part, ContextImagePart) for part in item.parts):
+                return True
+        return False
 
     @staticmethod
     def _build_data_uri_retry_target_size(limit_bytes: int) -> int:
@@ -1002,7 +1027,7 @@ class LLMOrchestrator:
                 task_display = self.request_type or "未知任务"
 
                 # 可重试的HTTP错误
-                can_retry_with_compression = self._can_retry_with_compressed_images(
+                can_retry_with_compression = self._can_retry_with_image_fallback(
                     active_request,
                     original_response_request,
                 )
@@ -1062,6 +1087,7 @@ class LLMOrchestrator:
                     and self.request_type.startswith("maisaka.")
                     and can_retry_with_compression
                     and self._is_unsupported_image_error(e)
+                    and self._has_image_part(active_request.context_items)
                 ):
                     logger.warning(
                         f"任务 '{task_display}' 的模型 '{model_info.name}' 返回 400 unsupported image，"

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -59,7 +59,7 @@ from src.llm_models.payload_content.tool_option import (
     ToolOption,
     normalize_tool_options,
 )
-from src.llm_models.utils import compress_messages, llm_usage_recorder
+from src.llm_models.utils import compress_messages, llm_usage_recorder, replace_images_with_text
 
 install(extra_lines=3)
 
@@ -71,6 +71,8 @@ DATA_URI_LIMIT_PATTERN = re.compile(
 )
 DATA_URI_RETRY_MARGIN_BYTES = 128 * 1024
 MIN_COMPRESSED_IMAGE_TARGET_SIZE_BYTES = 512 * 1024
+UNSUPPORTED_IMAGE_PATTERN = re.compile(r"unsupported image", re.IGNORECASE)
+"""识别视觉接口拒绝图片的错误关键词。"""
 EMPTY_TASK_FALLBACKS = {
     "expression_use": "utils",
     "learner": "utils",
@@ -205,6 +207,15 @@ class LLMOrchestrator:
                 return None
 
         return None
+
+    @staticmethod
+    def _is_unsupported_image_error(error: RespNotOkException) -> bool:
+        """判断错误是否为视觉接口拒绝图片（400 unsupported image）。"""
+        candidate_messages = [error.message, str(error)]
+        if error.__cause__ is not None:
+            candidate_messages.append(str(error.__cause__))
+
+        return any(UNSUPPORTED_IMAGE_PATTERN.search(candidate_message) for candidate_message in candidate_messages)
 
     @staticmethod
     def _build_data_uri_retry_target_size(limit_bytes: int) -> int:
@@ -1041,6 +1052,23 @@ class LLMOrchestrator:
                     # 压缩消息本身不消耗重试次数
                     compressed_messages = compress_messages(active_request.context_items)
                     active_request = active_request.copy_with(context_items=compressed_messages)
+                    update_failed_request_attempt(e, status="retrying")
+                    continue
+
+                # 特殊处理 400 unsupported image：将当前请求中的图片降级为纯文本后重试。
+                # 仅对 maisaka 规划器/回复器链路生效，且只对原始请求做一次兜底。
+                if (
+                    e.status_code == 400
+                    and self.request_type.startswith("maisaka.")
+                    and can_retry_with_compression
+                    and self._is_unsupported_image_error(e)
+                ):
+                    logger.warning(
+                        f"任务 '{task_display}' 的模型 '{model_info.name}' 返回 400 unsupported image，"
+                        f"尝试将图片降级为纯文本后重试..."
+                    )
+                    text_messages = replace_images_with_text(active_request.context_items)
+                    active_request = active_request.copy_with(context_items=text_messages)
                     update_failed_request_attempt(e, status="retrying")
                     continue
 

--- a/src/maisaka/context/messages.py
+++ b/src/maisaka/context/messages.py
@@ -7,6 +7,7 @@ from enum import Enum
 from io import BytesIO
 from typing import Any, Optional, Sequence
 import base64
+import math
 import uuid
 
 from PIL import Image as PILImage
@@ -96,14 +97,22 @@ def _normalize_maisaka_image(image_bytes: bytes, image_format: str) -> list[tupl
 
             aspect_ratio = max(width, height) / min(width, height)
             if aspect_ratio > MAISAKA_IMAGE_ASPECT_RATIO_LIMIT:
-                segments = _split_maisaka_image(image, width, height)
-                # 极长图片分割段数过多时，改为整体缩放，避免产生过多分段。
-                if len(segments) > MAISAKA_IMAGE_MAX_SEGMENTS:
+                # 先计算预计分段数，超过上限时直接整体缩放，避免为极长图创建大量裁剪对象。
+                long_side = max(width, height)
+                step = MAISAKA_IMAGE_MAX_SIDE - MAISAKA_IMAGE_SEGMENT_OVERLAP
+                segment_count = (
+                    1
+                    if long_side <= MAISAKA_IMAGE_MAX_SIDE
+                    else math.ceil((long_side - MAISAKA_IMAGE_MAX_SIDE) / step) + 1
+                )
+                if segment_count > MAISAKA_IMAGE_MAX_SEGMENTS:
                     logger.info(
-                        f"Maisaka 图片分割段数 {len(segments)} 超过上限 {MAISAKA_IMAGE_MAX_SEGMENTS}，"
+                        f"Maisaka 图片预计分段数 {segment_count} 超过上限 {MAISAKA_IMAGE_MAX_SEGMENTS}，"
                         f"改为整体缩放: {width}x{height}"
                     )
                     segments = [_resize_maisaka_image(image)]
+                else:
+                    segments = _split_maisaka_image(image, width, height)
             else:
                 segments = [image.copy()]
 
@@ -111,8 +120,7 @@ def _normalize_maisaka_image(image_bytes: bytes, image_format: str) -> list[tupl
             for segment in segments:
                 segment = _resize_maisaka_image(segment)
                 output_buffer = BytesIO()
-                if segment.mode in ("RGBA", "LA", "P", "I;16"):
-                    segment = segment.convert("RGB")
+                segment = _flatten_maisaka_image(segment)
                 segment.save(output_buffer, format="JPEG", quality=95, optimize=True)
                 normalized_segments.append(("jpeg", base64.b64encode(output_buffer.getvalue()).decode("utf-8")))
 
@@ -163,6 +171,23 @@ def _resize_maisaka_image(image: PILImage.Image) -> PILImage.Image:
     new_width = max(1, int(width * scale))
     new_height = max(1, int(height * scale))
     return image.resize((new_width, new_height), PILImage.Resampling.LANCZOS)
+
+
+def _flatten_maisaka_image(image: PILImage.Image) -> PILImage.Image:
+    """将带透明通道的图片合成到白色背景上，返回可保存为 JPEG 的 RGB 图。
+
+    对 RGBA、LA 以及含 transparency 信息的 P 模式图片，使用白色背景与 alpha
+    mask 合成，避免直接 convert("RGB") 丢弃透明度导致透明区域变黑。
+    """
+
+    if image.mode in ("RGBA", "LA") or (image.mode == "P" and "transparency" in image.info):
+        alpha_image = image.convert("RGBA")
+        background = PILImage.new("RGB", alpha_image.size, (255, 255, 255))
+        background.paste(alpha_image, mask=alpha_image.getchannel("A"))
+        return background
+    if image.mode in ("I;16", "I", "F"):
+        return image.convert("RGB")
+    return image.convert("RGB")
 
 
 def _append_emoji_component(

--- a/src/maisaka/context/messages.py
+++ b/src/maisaka/context/messages.py
@@ -55,6 +55,8 @@ MAISAKA_IMAGE_MAX_SIDE = 4096
 MAISAKA_IMAGE_ASPECT_RATIO_LIMIT = 3.0
 # 分割段之间的重叠像素，避免文字在分割边界被切断（按一般字体大小 16px 的 1.5 倍处理）。
 MAISAKA_IMAGE_SEGMENT_OVERLAP = 24
+# 单张图片分割的最大段数，超过时改为整体缩放，避免极长图片产生过多分段。
+MAISAKA_IMAGE_MAX_SEGMENTS = 10
 
 
 def _guess_image_format(image_bytes: bytes) -> Optional[str]:
@@ -95,6 +97,13 @@ def _normalize_maisaka_image(image_bytes: bytes, image_format: str) -> list[tupl
             aspect_ratio = max(width, height) / min(width, height)
             if aspect_ratio > MAISAKA_IMAGE_ASPECT_RATIO_LIMIT:
                 segments = _split_maisaka_image(image, width, height)
+                # 极长图片分割段数过多时，改为整体缩放，避免产生过多分段。
+                if len(segments) > MAISAKA_IMAGE_MAX_SEGMENTS:
+                    logger.info(
+                        f"Maisaka 图片分割段数 {len(segments)} 超过上限 {MAISAKA_IMAGE_MAX_SEGMENTS}，"
+                        f"改为整体缩放: {width}x{height}"
+                    )
+                    segments = [_resize_maisaka_image(image)]
             else:
                 segments = [image.copy()]
 
@@ -102,7 +111,7 @@ def _normalize_maisaka_image(image_bytes: bytes, image_format: str) -> list[tupl
             for segment in segments:
                 segment = _resize_maisaka_image(segment)
                 output_buffer = BytesIO()
-                if segment.mode in ("RGBA", "LA", "P"):
+                if segment.mode in ("RGBA", "LA", "P", "I;16"):
                     segment = segment.convert("RGB")
                 segment.save(output_buffer, format="JPEG", quality=95, optimize=True)
                 normalized_segments.append(("jpeg", base64.b64encode(output_buffer.getvalue()).decode("utf-8")))

--- a/src/maisaka/context/messages.py
+++ b/src/maisaka/context/messages.py
@@ -25,6 +25,7 @@ from src.common.data_models.message_component_data_model import (
     TextComponent,
     VoiceComponent,
 )
+from src.common.logger import get_logger
 from src.llm_models.payload_content.context_item import (
     AssistantMessageItem,
     ContextItem,
@@ -41,10 +42,19 @@ from src.llm_models.payload_content.context_item import (
 )
 from src.llm_models.payload_content.tool_option import ToolCall
 
+logger = get_logger("maisaka_context_messages")
+
 FORWARD_PREVIEW_LIMIT = 4
 FOCUS_COOLDOWN_WAKEUP_SOURCE = "focus_cooldown_wakeup"
 FOCUS_AT_WAKEUP_SOURCE = "focus_at_wakeup"
 FOCUS_WAKEUP_SOURCE_KINDS = frozenset({FOCUS_COOLDOWN_WAKEUP_SOURCE, FOCUS_AT_WAKEUP_SOURCE})
+
+# 视觉模型对单张图片单边像素的限制（请求含 15 张及以上图片时降为 4096，这里按最低限制处理）。
+MAISAKA_IMAGE_MAX_SIDE = 4096
+# 长宽比超过该值时对长边进行分割，避免超长/超宽图被视觉接口拒绝。
+MAISAKA_IMAGE_ASPECT_RATIO_LIMIT = 3.0
+# 分割段之间的重叠像素，避免文字在分割边界被切断（按一般字体大小 16px 的 1.5 倍处理）。
+MAISAKA_IMAGE_SEGMENT_OVERLAP = 24
 
 
 def _guess_image_format(image_bytes: bytes) -> Optional[str]:
@@ -58,6 +68,94 @@ def _guess_image_format(image_bytes: bytes) -> Optional[str]:
         return None
 
 
+def _normalize_maisaka_image(image_bytes: bytes, image_format: str) -> list[tuple[str, str]]:
+    """将 Maisaka 链路（规划器/回复器）的图片规范化为视觉模型可接受的图片列表。
+
+    处理流程：
+    1. 检查比例：长宽比超过 3:1 的，对长边进行分割（超长图沿高度切，超宽图沿宽度切），
+       每段最长边不超过 4096，段间保留少量重叠避免文字被切断。
+    2. 检查尺寸：对单边超过 4096 的图片（含分割后仍超限的）进行等比例缩放。
+
+    返回 `(image_format, image_base64)` 列表，调用方应在同一个 user 块内逐张追加。
+    """
+    try:
+        with PILImage.open(BytesIO(image_bytes)) as image:
+            image_format = (image.format or image_format or "").lower()
+            if image_format in {"jpg", "jpeg"}:
+                image_format = "jpeg"
+
+            # 动图保持原逻辑（下游会转首帧），不做分割/缩放。
+            if getattr(image, "is_animated", False):
+                return [(image_format, base64.b64encode(image_bytes).decode("utf-8"))]
+
+            width, height = image.size
+            if width <= 0 or height <= 0:
+                return [(image_format, base64.b64encode(image_bytes).decode("utf-8"))]
+
+            aspect_ratio = max(width, height) / min(width, height)
+            if aspect_ratio > MAISAKA_IMAGE_ASPECT_RATIO_LIMIT:
+                segments = _split_maisaka_image(image, width, height)
+            else:
+                segments = [image.copy()]
+
+            normalized_segments: list[tuple[str, str]] = []
+            for segment in segments:
+                segment = _resize_maisaka_image(segment)
+                output_buffer = BytesIO()
+                if segment.mode in ("RGBA", "LA", "P"):
+                    segment = segment.convert("RGB")
+                segment.save(output_buffer, format="JPEG", quality=95, optimize=True)
+                normalized_segments.append(("jpeg", base64.b64encode(output_buffer.getvalue()).decode("utf-8")))
+
+            return normalized_segments
+    except Exception as exc:
+        logger.warning(f"Maisaka 图片规范化失败，保持原图发送: {exc}")
+        return [(image_format, base64.b64encode(image_bytes).decode("utf-8"))]
+
+
+def _split_maisaka_image(image: PILImage.Image, width: int, height: int) -> list[PILImage.Image]:
+    """沿长边将超长/超宽图分割为多段，每段最长边不超过 4096，段间保留重叠。"""
+
+    if width >= height:
+        # 超宽图：沿宽度方向分割
+        segment_length = MAISAKA_IMAGE_MAX_SIDE
+        segments: list[PILImage.Image] = []
+        start = 0
+        while start < width:
+            end = min(start + segment_length, width)
+            segments.append(image.crop((start, 0, end, height)))
+            if end >= width:
+                break
+            start = end - MAISAKA_IMAGE_SEGMENT_OVERLAP
+        return segments
+
+    # 超长图：沿高度方向分割
+    segment_length = MAISAKA_IMAGE_MAX_SIDE
+    segments = []
+    start = 0
+    while start < height:
+        end = min(start + segment_length, height)
+        segments.append(image.crop((0, start, width, end)))
+        if end >= height:
+            break
+        start = end - MAISAKA_IMAGE_SEGMENT_OVERLAP
+    return segments
+
+
+def _resize_maisaka_image(image: PILImage.Image) -> PILImage.Image:
+    """将单边超过 4096 的图片等比例缩放到限制内。"""
+
+    width, height = image.size
+    max_side = max(width, height)
+    if max_side <= MAISAKA_IMAGE_MAX_SIDE:
+        return image
+
+    scale = MAISAKA_IMAGE_MAX_SIDE / max_side
+    new_width = max(1, int(width * scale))
+    new_height = max(1, int(height * scale))
+    return image.resize((new_width, new_height), PILImage.Resampling.LANCZOS)
+
+
 def _append_emoji_component(
     builder: ContextItemBuilder,
     component: EmojiComponent,
@@ -68,7 +166,8 @@ def _append_emoji_component(
     image_format = _guess_image_format(component.binary_data)
     if enable_visual_message and image_format and component.binary_data:
         builder.add_text_content("[消息类型]表情包")
-        builder.add_image_content(image_format, base64.b64encode(component.binary_data).decode("utf-8"))
+        for sub_format, sub_base64 in _normalize_maisaka_image(component.binary_data, image_format):
+            builder.add_image_content(sub_format, sub_base64)
         return True
 
     normalized_content = component.content.strip()
@@ -89,7 +188,8 @@ def _append_image_component(
     """将图片组件追加到 LLM 消息构建器。"""
     image_format = _guess_image_format(component.binary_data)
     if enable_visual_message and image_format and component.binary_data:
-        builder.add_image_content(image_format, base64.b64encode(component.binary_data).decode("utf-8"))
+        for sub_format, sub_base64 in _normalize_maisaka_image(component.binary_data, image_format):
+            builder.add_image_content(sub_format, sub_base64)
         return True
 
     normalized_content = component.content.strip()
@@ -264,9 +364,7 @@ def _render_components_for_browser(
     for component in components:
         if isinstance(component, ForwardNodeComponent):
             nested_path = [*parent_path, nested_component_index]
-            rendered_parts.append(
-                f"[嵌套转发消息，path={nested_path}，可再次调用 view_forward_message 展开]"
-            )
+            rendered_parts.append(f"[嵌套转发消息，path={nested_path}，可再次调用 view_forward_message 展开]")
             nested_component_index += 1
             continue
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并

# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）: 无
7. 请简要说明本次更新的内容和目的：

## 问题

群聊中出现**超长截图**（如 700×10800 的聊天记录长截图）时，多模态 planner 请求直接失败，导致整轮思考中断、麦麦完全不回复。

报错为 DeepSeek 视觉 API 返回 400 `unsupported image`。图片文件本身是合法 JPEG，但因其**像素尺寸/长宽比过大**（约 15.4:1），被视觉接口判定为 unsupported image。400 属于不可重试硬错误，直接导致整轮思考崩溃。

## 修复内容

### 1. 超长/超宽图分割或缩放（`src/maisaka/context/messages.py`）

在 Maisaka 规划器/回复器发送图片前进行规范化：

- **检查比例**：长宽比超过 3:1 的，对长边进行分割（超长图沿高度切、超宽图沿宽度切），每段最长边不超过 4096，段间保留 24px 重叠避免文字被切断
- **检查尺寸**：对单边超过 4096 的图片（含分割后仍超限的）进行等比例缩放
- 分割后的多段图片在**同一个 user 块内**发送（符合 DeepSeek 官方多图支持）
- GIF 动图保持原逻辑（下游会转首帧）
- **仅影响 maisaka 规划器/回复器链路**，VLM 识图（`src/chat/image_system/image_manager.py`）不受影响

### 2. 400 unsupported image 兜底（`src/llm_models/utils.py`、`src/llm_models/utils_model.py`）

当视觉接口仍拒绝图片（400 `unsupported image`）时，将当前请求中的图片降级为纯文本占位符后重试：

- 仅对 maisaka 规划器/回复器链路生效（`request_type` 以 `maisaka.` 开头）
- 仅对原始请求做一次兜底，避免无限重试
- 旧上下文（历史消息）维持多模态，只降级当前请求中的图片
- VLM 识图链路不受影响

## 测试

- 新增 `pytests/maisaka/test_maisaka_image_normalize.py`（7 个用例）：普通图不变、超长图分割、超宽图分割、超大图缩放、分割重叠、GIF 动图保持原样、`_append_image_component` 追加多图
- 新增 `pytests/test_image_text_fallback.py`（7 个用例）：图片降级为文本、错误识别
- 相关现有测试全部通过（无回归）
- 实战测试通过

# 其他信息
- **关联 Issue**：#1999
- **截图/GIF**：
- **附加信息**: 已在 #1999 下补充超长图触发场景的完整分析


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化图片处理：超长或超宽图片会自动分割、缩放并转换格式，透明图片将合成白色背景，动图保持原样。
  - 当视觉接口不支持图片时，自动将图片替换为文本占位符并重试。
- **错误修复**
  - 改善复杂图片内容的发送稳定性，避免因图片尺寸或接口限制导致请求失败。
- **测试**
  - 新增图片规范化及图片转文本降级逻辑的全面测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->