### PR TITLE
feat(config): add OrcaRouter as a named provider template

### DIFF
--- a/dashboard/src/routes/config/__tests__/providerTemplates.test.ts
+++ b/dashboard/src/routes/config/__tests__/providerTemplates.test.ts
@@ -40,4 +40,12 @@ describe('providerTemplates', () => {
   it('直接按 URL 查找模板时不把未知 URL 识别为内置模板', () => {
     expect(findTemplateByBaseUrl('https://example.com/v1')).toBeNull()
   })
+
+  it('识别 OrcaRouter 内置模板并支持模型列表获取', () => {
+    const template = findTemplateByBaseUrl('https://api.orcarouter.ai/v1')
+
+    expect(template?.id).toBe('orcarouter')
+    expect(template?.display_name).toBe('OrcaRouter')
+    expect(template?.modelFetcher).toEqual({ endpoint: '/models', parser: 'openai' })
+  })
 })

--- a/dashboard/src/routes/config/providerTemplates.ts
+++ b/dashboard/src/routes/config/providerTemplates.ts
@@ -151,6 +151,14 @@ export const PROVIDER_TEMPLATES: ProviderTemplate[] = [
     modelFetcher: { endpoint: '/models', parser: 'openai' },
   },
   {
+    id: 'orcarouter',
+    name: 'OrcaRouter',
+    base_url: 'https://api.orcarouter.ai/v1',
+    client_type: 'openai',
+    display_name: 'OrcaRouter',
+    modelFetcher: { endpoint: '/models', parser: 'openai' },
+  },
+  {
     id: 'mistral',
     name: 'Mistral',
     base_url: 'https://api.mistral.ai/v1',

--- a/src/llm_models/model_client/openai_client.py
+++ b/src/llm_models/model_client/openai_client.py
@@ -148,6 +148,7 @@ OpenAIResponseParser = Callable[[ChatCompletion], Tuple[APIResponse, UsageTuple 
 PROVIDER_REASONING_KEYS_BY_DOMAIN: Dict[str, str] = {
     "api.groq.com": "reasoning",
     "openrouter.ai": "reasoning",
+    "api.orcarouter.ai": "reasoning",
 }
 """按 provider 域名指定的原生推理字段名。"""
 


### PR DESCRIPTION
## What

This PR adds **OrcaRouter** as a first-class, named provider for MaiBot — exactly parallel to how the existing OpenAI-compatible providers (e.g. Groq, Mistral, Perplexity) are wired in the dashboard. Users can pick "OrcaRouter" from the provider template list instead of treating it as an anonymous custom base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means MaiBot users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes (file by file)

- `dashboard/src/routes/config/providerTemplates.ts` — added an `orcarouter` entry to the built-in `PROVIDER_TEMPLATES`, mirroring the existing `groq` / `mistral` entries (OpenAI-compatible `client_type`, `base_url: https://api.orcarouter.ai/v1`, and a `/models` `modelFetcher`). This makes the provider selectable in the WebUI provider form and setup wizard, and lets the model list be fetched automatically.
- `src/llm_models/model_client/openai_client.py` — added `"api.orcarouter.ai": "reasoning"` to `PROVIDER_REASONING_KEYS_BY_DOMAIN`, mirroring the existing `"openrouter.ai"` entry, so native reasoning fields from OrcaRouter-routed models are parsed the same way.
- `dashboard/src/routes/config/__tests__/providerTemplates.test.ts` — added a test that `findTemplateByBaseUrl('https://api.orcarouter.ai/v1')` resolves to the new `orcarouter` template with the expected `/models` fetcher.

## Verification

- `bun run typecheck` — passed
- `bun run lint` — passed (0 errors)
- `bun run test:run` — passed (3297 tests)
- `bun run build` — passed
- `ruff check src/llm_models/model_client/openai_client.py` — passed
- Live-tested the new wiring against `https://api.orcarouter.ai/v1` with the OpenAI SDK used by the project's OpenAI-compatible client: `GET /models` returned 204 models and `chat.completions.create` with `deepseek/deepseek-v4-flash` returned HTTP 200.

## Checklist

- [x] This branch is **not** `main` (base is `dev`, per the contribution guide)
- [x] I have read the contribution guide
- [x] Change type: feature
- [x] Change has been tested (see Verification)
- [x] Not touching `src/A_memorix`
- [ ] Breaking changes: none

## Notes

- **Related Issue**: none (small provider-template addition, no architecture change)
- **Screenshots**: n/a
- **Contact**: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
- I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 OrcaRouter 提供商支持，可通过 OpenAI 兼容接口配置并获取模型列表。
  * 支持正确读取 OrcaRouter 返回的推理内容。

* **测试**
  * 增加 OrcaRouter 内置模板的识别与配置校验测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->