### PR TITLE
feat(planner): add strip_assistant_messages config switch (#2017)

### DIFF
--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -613,6 +613,18 @@ class ChatReplyTimingConfig(ConfigBase):
     )
     """控制新消息何时进入 Planner。"""
 
+    strip_assistant_messages: bool = Field(
+        default=False,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "过滤历史助手消息",
+                "en_US": "Strip assistant messages in planner",
+                "ja_JP": "プランナーでアシスタントメッセージを除去",
+            },
+        },
+    )
+    """启用后在向 Planner 模型发送请求前过滤掉历史中的 assistant 消息，避免因包含未调用工具的推理内容影响模型正常决策。"""
+
     planner_interrupt_max_consecutive_count: int = Field(
         default=0,
         ge=0,


### PR DESCRIPTION
### Summary

Fixes #2017.

Adds the `strip_assistant_messages` boolean configuration option to `ChatReplyTimingConfig` in `src/config/official_configs.py`. When reasoning-oriented models (such as DeepSeek V4) are deployed as the planner, historical assistant messages containing non-tool text decisions can degrade subsequent tool-calling reliability; this configuration provides the required switch to filter them out before dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增可选配置，用于在向 Planner 模型发送请求前过滤历史助手消息。
  * 该配置默认关闭，现有行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->