### PR TITLE
fix: 修复 Docker 停机时 Worker 清理与停止请求丢失

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,37 +7,20 @@ import asyncio
 import hashlib
 import os
 import platform
+
 # import shutil
 import signal
-import subprocess
 import sys
 import time
 import traceback
 
-from src.common.i18n import set_locale, t, tn
-from src.common.logger import get_logger, initialize_logging, shutdown_logging
-from src.common.runtime_loop import set_main_loop
-from src.common.shutdown import request_shutdown
-from src.common.update_notice import emit_terminal_update_notice_if_needed
-from src.config.legacy_upgrade_confirmation import require_legacy_upgrade_confirmation
-
-# 设置工作目录为脚本所在目录
-script_dir = os.path.dirname(os.path.abspath(__file__))
-os.chdir(script_dir)
-set_locale(os.getenv("MAIBOT_LOCALE", "zh-CN"))
-
-# 检查是否是 Worker 进程，只在 Worker 进程中输出详细的初始化信息
-# Runner 进程只需要基本的日志功能，不需要详细的初始化日志
-is_worker = os.environ.get("MAIBOT_WORKER_PROCESS") == "1"
-initialize_logging(verbose=is_worker)
-install(extra_lines=3)
-logger = get_logger("main")
-
-# 定义重启退出码
-RESTART_EXIT_CODE = 42
+# 在业务导入前接管 Worker 信号；此时只记录停止请求，不调用尚未初始化的组件。
 _active_main_loop: asyncio.AbstractEventLoop | None = None
 _active_main_task: asyncio.Task[None] | None = None
 _shutdown_signal_count: int = 0
+_shutdown_task: asyncio.Task[bool] | None = None
+_shutdown_deadline: float | None = None
+SHUTDOWN_TIMEOUT = 50.0  # 为 Runner 的 60 秒硬截止保留余量。
 _RunResultT = TypeVar("_RunResultT")
 # print("-----------------------------------------")
 # print("\n\n\n\n\n")
@@ -57,11 +40,13 @@ def _mark_shutdown_and_interrupt(_signum: int, _frame: object) -> None:
 
     global _shutdown_signal_count
     _shutdown_signal_count += 1
-    request_shutdown("signal")
+    if _shutdown_signal_count > 1 or _shutdown_task is not None:
+        return
     main_loop = _active_main_loop
     if main_loop is None or main_loop.is_closed():
         return
 
+    request_shutdown("signal")
     try:
         main_loop.call_soon_threadsafe(_cancel_active_main_task_from_signal)
     except RuntimeError:
@@ -71,9 +56,56 @@ def _mark_shutdown_and_interrupt(_signum: int, _frame: object) -> None:
 def _cancel_active_main_task_from_signal() -> None:
     """在事件循环线程中取消当前主任务。"""
 
-    if _active_main_task is None or _active_main_task.done():
+    if (
+        _shutdown_task is not None
+        or _active_main_task is None
+        or _active_main_task.done()
+        or _active_main_task.cancelling()
+    ):
         return
     _active_main_task.cancel()
+
+
+def _set_active_main_task(task: asyncio.Task[None]) -> None:
+    """先发布任务，再消费停止标记；交接前的请求和交接后的回调都不会丢失。"""
+    global _active_main_task
+    _active_main_task = task
+    if _shutdown_signal_count:
+        request_shutdown("signal")
+        _cancel_active_main_task_from_signal()
+
+
+def _install_early_worker_signal_handlers() -> None:
+    """允许慢速导入期间收到的停止请求在事件循环就绪后被消费。"""
+    signals = [signal.SIGINT, signal.SIGTERM]
+    if hasattr(signal, "SIGBREAK"):
+        signals.append(signal.SIGBREAK)
+    for sig in signals:
+        signal.signal(sig, _mark_shutdown_and_interrupt)
+
+
+if __name__ == "__main__" and os.environ.get("MAIBOT_WORKER_PROCESS") == "1":
+    _install_early_worker_signal_handlers()
+
+
+from src.common.i18n import set_locale, t, tn  # noqa: E402
+from src.common.logger import get_logger, initialize_logging, shutdown_logging  # noqa: E402
+from src.common.runtime_loop import set_main_loop  # noqa: E402
+from src.common.process_runner import RESTART_EXIT_CODE, supervise_worker  # noqa: E402
+from src.common.shutdown import application_signal_handlers, request_shutdown  # noqa: E402
+from src.common.update_notice import emit_terminal_update_notice_if_needed  # noqa: E402
+from src.config.legacy_upgrade_confirmation import require_legacy_upgrade_confirmation  # noqa: E402
+
+# 设置工作目录为脚本所在目录
+script_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(script_dir)
+set_locale(os.getenv("MAIBOT_LOCALE", "zh-CN"))
+
+# Runner 只需要基本日志；详细组件初始化由 Worker 输出。
+is_worker = os.environ.get("MAIBOT_WORKER_PROCESS") == "1"
+initialize_logging(verbose=is_worker)
+install(extra_lines=3)
+logger = get_logger("main")
 
 
 def run_runner_process():
@@ -88,39 +120,9 @@ def run_runner_process():
     env = os.environ.copy()
     env["MAIBOT_WORKER_PROCESS"] = "1"
 
-    while True:
-        logger.info(t("startup.launching_script", script_file=script_file))
-
-        # 启动子进程 (Worker)
-        # 使用 sys.executable 确保使用相同的 Python 解释器
-        cmd = [python_executable, script_file] + sys.argv[1:]
-
-        process = subprocess.Popen(cmd, env=env)
-
-        try:
-            # 等待子进程结束
-            return_code = process.wait()
-
-            if return_code == RESTART_EXIT_CODE:
-                logger.info(t("startup.restart_requested", exit_code=RESTART_EXIT_CODE))
-                time.sleep(1)  # 稍作等待
-                continue
-            else:
-                logger.info(t("startup.program_exited", return_code=return_code))
-                sys.exit(return_code)
-
-        except KeyboardInterrupt:
-            # 向子进程发送终止信号
-            if process.poll() is None:
-                # 在 Windows 上，Ctrl+C 通常已经发送给了子进程（如果它们共享控制台）
-                # 但为了保险，我们可以尝试 terminate
-                try:
-                    process.terminate()
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    logger.warning(t("startup.child_process_force_kill"))
-                    process.kill()
-            sys.exit(0)
+    logger.info(t("startup.launching_script", script_file=script_file))
+    cmd = [python_executable, script_file] + sys.argv[1:]
+    sys.exit(supervise_worker(cmd, env, logger))
 
 
 # 检查是否是 Worker 进程
@@ -208,42 +210,87 @@ def easter_egg():
     print(rainbow_text)
 
 
-async def graceful_shutdown(main_system: MainSystem | None = None):  # sourcery skip: use-named-expression
+async def graceful_shutdown(main_system: MainSystem | None = None) -> bool:
+    global _shutdown_deadline
+    _shutdown_deadline = time.monotonic() + SHUTDOWN_TIMEOUT
     try:
         request_shutdown("graceful_shutdown")
         logger.info(t("startup.shutdown_started"))
+        success = True
 
         # 关闭 WebUI 服务器
-        try:
-            if main_system is not None and main_system.webui_server is not None:
-                await main_system.webui_server.shutdown()
-        except Exception as e:
-            logger.warning(f"关闭 WebUI 服务器时出错: {e}")
+        if main_system is not None and main_system.webui_server is not None:
+            success = (
+                await _await_shutdown_step(main_system.webui_server.shutdown(), timeout=5.0, step_name="关闭 WebUI")
+                and success
+            )
+
+        from src.config.config import config_manager
+
+        success = (
+            await _await_shutdown_step(config_manager.stop_file_watcher(), timeout=5.0, step_name="停止配置监听")
+            and success
+        )
+        if main_system is not None and main_system.app is not None:
+            success = (
+                await _await_shutdown_step(main_system.app.stop(), timeout=5.0, step_name="停止消息入口") and success
+            )
 
         from src.core.event_bus import event_bus
         from src.core.types import EventType
 
         # 触发 ON_STOP 事件
-        await _await_shutdown_step(
-            event_bus.emit(event_type=EventType.ON_STOP),
-            timeout=5.0,
-            step_name="触发 ON_STOP 事件",
+        success = (
+            await _await_shutdown_step(
+                event_bus.emit(event_type=EventType.ON_STOP),
+                timeout=5.0,
+                step_name="触发 ON_STOP 事件",
+            )
+            and success
         )
 
         # 停止新版本插件运行时
         from src.plugin_runtime.integration import get_plugin_runtime_manager
 
-        await _await_shutdown_step(
-            get_plugin_runtime_manager().stop(),
-            timeout=8.0,
-            step_name="停止插件运行时",
+        success = (
+            await _await_shutdown_step(
+                get_plugin_runtime_manager().stop(),
+                timeout=8.0,
+                step_name="停止插件运行时",
+            )
+            and success
         )
 
+        # 先停止记忆写入者，再等待内核持久化、关闭存储和释放 writer lock。
+        # 必须早于 remaining_tasks 的粗粒度取消。
+        from src.A_memorix.host_service import a_memorix_host_service
+        from src.services.memory_flow_service import memory_automation_service
+        from src.emoji_system.emoji_manager import emoji_manager
+        from src.mcp_module.service import get_mcp_service
+
+        success = (
+            await _await_shutdown_step(memory_automation_service.shutdown(), timeout=5.0, step_name="停止记忆自动写入")
+            and success
+        )
+        success = (
+            await _await_shutdown_step(a_memorix_host_service.stop(), timeout=30.0, step_name="关闭 A_Memorix 并持久化")
+            and success
+        )
+        try:
+            emoji_manager.shutdown()
+        except Exception:
+            logger.exception("Emoji 清理失败，继续后续关闭步骤")
+            success = False
+        success = await _await_shutdown_step(get_mcp_service().close(), timeout=5.0, step_name="关闭 MCP") and success
+
         # 停止所有异步任务
-        await _await_shutdown_step(
-            async_task_manager.stop_and_wait_all_tasks(),
-            timeout=5.0,
-            step_name="停止异步任务管理器任务",
+        success = (
+            await _await_shutdown_step(
+                async_task_manager.stop_and_wait_all_tasks(),
+                timeout=5.0,
+                step_name="停止异步任务管理器任务",
+            )
+            and success
         )
 
         # 获取所有剩余任务，排除当前任务
@@ -259,32 +306,48 @@ async def graceful_shutdown(main_system: MainSystem | None = None):  # sourcery 
 
             # 等待所有任务完成，设置超时
             try:
-                await asyncio.wait_for(asyncio.gather(*remaining_tasks, return_exceptions=True), timeout=5.0)
+                await asyncio.wait_for(
+                    asyncio.gather(*remaining_tasks, return_exceptions=True), timeout=_shutdown_time_left(5.0)
+                )
                 logger.info(t("startup.remaining_tasks_cancelled"))
             except asyncio.TimeoutError:
                 logger.warning(t("startup.remaining_tasks_cancel_timeout"))
+                success = False
             except Exception as e:
                 logger.error(t("startup.remaining_tasks_cancel_error", error=e))
+                success = False
 
-        logger.info(t("startup.shutdown_completed"))
+        if success:
+            logger.info(t("startup.shutdown_completed"))
+        else:
+            logger.error("应用优雅关闭未完成；退出状态为失败")
+        return success
 
     except Exception as e:
         logger.error(t("startup.shutdown_failed", error=e), exc_info=True)
+        return False
 
 
-async def _await_shutdown_step(awaitable, *, timeout: float, step_name: str):
-    """为关停步骤设置硬超时，避免单个组件阻塞 Ctrl+C 退出。"""
+def _shutdown_time_left(step_timeout: float) -> float:
+    if _shutdown_deadline is None:
+        return step_timeout
+    return min(step_timeout, max(0.0, _shutdown_deadline - time.monotonic()))
+
+
+async def _await_shutdown_step(awaitable, *, timeout: float, step_name: str) -> bool:
+    """步骤共享关闭预算；不响应取消/阻塞事件循环的代码最终由 Runner 有界终止。"""
 
     try:
-        return await asyncio.wait_for(awaitable, timeout=timeout)
+        await asyncio.wait_for(awaitable, timeout=_shutdown_time_left(timeout))
+        return True
     except asyncio.TimeoutError:
         logger.warning(f"{step_name} 超时，继续执行后续关停步骤")
-        return None
+        return False
     except asyncio.CancelledError:
         raise
     except Exception as exc:
         logger.warning(f"{step_name} 失败，继续执行后续关停步骤: {exc}", exc_info=True)
-        return None
+        return False
 
 
 def _cancel_main_task(main_loop: asyncio.AbstractEventLoop | None, main_task: asyncio.Task[None] | None) -> None:
@@ -330,15 +393,18 @@ def _run_graceful_shutdown(
     main_system: MainSystem | None,
 ) -> bool:
     """在同步入口中执行异步优雅关闭。"""
+    global _shutdown_task
     if main_loop is None or main_loop.is_closed():
         return False
 
     try:
-        shutdown_task = main_loop.create_task(graceful_shutdown(main_system))
-        _run_until_complete(main_loop, shutdown_task)
-        return True
+        if _shutdown_task is None:
+            _shutdown_task = main_loop.create_task(graceful_shutdown(main_system))
+        return _run_until_complete(main_loop, _shutdown_task)
     except KeyboardInterrupt:
         _print_interrupt_exit_notice()
+    except asyncio.CancelledError:
+        logger.error("应用优雅关闭任务被取消；关闭未完成")
     except Exception as ge:
         logger.error(t("startup.graceful_shutdown_error", error=ge))
     return False
@@ -460,6 +526,7 @@ if __name__ == "__main__":
     main_system: MainSystem | None = None
     main_tasks: asyncio.Task[None] | None = None
     shutdown_completed = False
+    worker_signals = None
     try:
         # 获取MainSystem实例
         main_system = raw_main()
@@ -469,7 +536,8 @@ if __name__ == "__main__":
         asyncio.set_event_loop(loop)
         set_main_loop(loop)
         _active_main_loop = loop
-        signal.signal(signal.SIGINT, _mark_shutdown_and_interrupt)
+        worker_signals = application_signal_handlers(_mark_shutdown_and_interrupt)
+        worker_signals.__enter__()
 
         # 初始化 WebSocket 日志推送
         from src.common.logger import initialize_ws_handler
@@ -479,10 +547,10 @@ if __name__ == "__main__":
         try:
             # 执行初始化和任务调度
             initialize_task = loop.create_task(main_system.initialize())
-            _active_main_task = initialize_task
+            _set_active_main_task(initialize_task)
             _run_until_complete(loop, initialize_task)
             main_tasks = loop.create_task(main_system.schedule_tasks())
-            _active_main_task = main_tasks
+            _set_active_main_task(main_tasks)
             _run_until_complete(loop, main_tasks)
 
         except KeyboardInterrupt:
@@ -529,6 +597,12 @@ if __name__ == "__main__":
             shutdown_completed = _run_graceful_shutdown(loop, main_system)
         exit_code = 1  # 标记发生错误
     finally:
+        # 覆盖初始化异常、正常任务返回及 restart=42；关闭失败不得伪装成成功。
+        if loop is not None and not loop.is_closed():
+            _cancel_main_task(loop, main_tasks)
+            shutdown_completed = _run_graceful_shutdown(loop, main_system)
+            if not shutdown_completed:
+                exit_code = 1
         try:
             # 确保 loop 在任何情况下都尝试关闭（如果存在且未关闭）
             if "loop" in locals() and loop and not loop.is_closed():
@@ -547,6 +621,9 @@ if __name__ == "__main__":
             print(t("startup.prepare_exit"))
         except KeyboardInterrupt:
             _print_interrupt_exit_notice()
+
+        if worker_signals is not None:
+            worker_signals.__exit__(None, None, None)
 
         # 使用 os._exit() 强制退出，避免被阻塞
         # 由于已经在 graceful_shutdown() 中完成了所有清理工作，这是安全的

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   core:
     container_name: maim-bot-core
+    stop_grace_period: 70s # Runner 最多等待 Worker 60 秒，再保留强制退出时间
     #### prod ####
     image: sengokucola/maibot:latest
     # image: infinitycat/maibot:latest

--- a/pytests/A_memorix_test/test_host_shutdown_failure_propagation.py
+++ b/pytests/A_memorix_test/test_host_shutdown_failure_propagation.py
@@ -1,0 +1,85 @@
+"""真实 Host → Kernel 生命周期；存储替身仅记录调用或抛出故障。"""
+
+from pathlib import Path
+
+import asyncio
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("failure", [None, "persist", "metadata_close"])
+def test_host_awaits_kernel_and_propagates_storage_failure(tmp_path, failure):
+    # 新解释器隔离模块缓存；不污染常规 pytest 会话，也不导入宿主配置/业务数据库。
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytests.A_memorix_test.test_host_shutdown_failure_propagation",
+            str(tmp_path),
+            failure or "normal",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+        env=os.environ | {"PYTHONUTF8": "1", "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+async def check_host_shutdown(tmp_path, monkeypatch, failure):
+    from src.A_memorix.host_service import AMemorixHostService
+    from src.A_memorix.core.runtime.sdk_memory_kernel import SDKMemoryKernel
+
+    events = []
+    kernel = SDKMemoryKernel(plugin_root=tmp_path, config={"storage": {"data_dir": str(tmp_path / "memory")}})
+    kernel._runtime_writer_lock.acquire()
+    kernel._initialized = True
+
+    class Metadata:
+        def close(self):
+            events.append("metadata_close")
+            if failure == "metadata_close":
+                raise RuntimeError("fixture metadata close failed")
+
+    async def stop_background():
+        events.append("stop_background")
+
+    def persist():
+        events.append("persist")
+        if failure == "persist":
+            raise RuntimeError("fixture persist failed")
+
+    kernel.metadata_store = Metadata()
+    monkeypatch.setattr(kernel, "_stop_background_tasks", stop_background)
+    monkeypatch.setattr(kernel, "_persist", persist)
+    # 不读取实际 config 或启动 Host；仅构造 stop() 所需的状态。
+    host = object.__new__(AMemorixHostService)
+    host._lock = asyncio.Lock()
+    host._startup_task = None
+    host._kernel = kernel
+    host._runtime_state = "running"
+    try:
+        if failure:
+            with pytest.raises(RuntimeError, match="fixture"):
+                await host.stop()
+        else:
+            await host.stop()
+            assert host._kernel is None
+            assert host._runtime_state == "stopped"
+        assert events == ["stop_background", "persist", "metadata_close"]
+        assert not kernel._runtime_writer_lock.held
+        assert not kernel._initialized
+    finally:
+        kernel._runtime_writer_lock.release()
+
+
+if __name__ == "__main__":
+    from pytests.startup_test.memory_shutdown_fixture import isolated
+
+    with isolated() as patch:
+        asyncio.run(check_host_shutdown(Path(sys.argv[1]), patch, None if sys.argv[2] == "normal" else sys.argv[2]))

--- a/pytests/startup_test/README.md
+++ b/pytests/startup_test/README.md
@@ -1,0 +1,46 @@
+# Graceful shutdown regression tests
+
+## 本地运行
+
+使用已有项目开发依赖，从仓库根目录执行：
+
+```sh
+python -m pytest pytests/startup_test/test_graceful_shutdown.py pytests/A_memorix_test/test_host_shutdown_failure_propagation.py -q -p no:cacheprovider
+```
+
+不需要真实模型、QQ、配置或生产数据库。`shutdown_fixture.py` 用 AST 加载实际
+`bot.py` 生命周期函数与 Worker 入口，业务服务为替身，Uvicorn 信号上下文是真实实现。
+Host/Kernel 失败传播测试在新解释器中运行；`memory_shutdown_fixture.py` 在导入真实
+A_Memorix 生命周期前隔离宿主配置、业务数据库和网络，避免污染其他测试的模块缓存。
+存储替身只证明调用顺序/错误传播，其标记不是实际向量/图落盘证据。
+
+## 覆盖与边界
+
+- Runner 单次转发、等待、超时失败、restart=42 与停止竞争。
+- Worker 重复 SIGTERM/SIGINT、Uvicorn handler 恢复、early-startup 停止。
+- 初始化尚未完成、初始化末尾正常返回、初始化刚完成、scheduler 发布前/后及已经启动时
+  的停止请求交接。任务发布后再次消费持久停止标记，已排队的回调不能重复取消同一任务。
+- A_Memorix stop 恰好一次且早于剩余任务取消；关闭失败不能输出成功标记。
+- 真实 Host → Kernel 的 persist/metadata close 异常传播及 writer-lock 释放。
+
+四项 POSIX 子进程信号测试在 Windows 明确 skipped；其他 Windows 信号测试用
+`signal.raise_signal`，不把 `terminate()` 冒充 POSIX SIGTERM。发布边界测试在本地
+fixture/任务上注入时序，不连接或调试生产进程。不包含 fork 专用 workflow、固定 Git SHA、
+证据 observer、JUnit 搬运或 Docker acceptance harness。
+
+## 关闭语义
+
+Worker 合作式总预算为 50 秒；其中 A_Memorix stop 单步骤最多 30 秒，实际还受剩余总预算限制。
+超时会取消协程并失败退出：若取消发生在后台/manager 退出阶段，尚未进入 persist/close，
+就不能宣称数据已落盘；本修复不重新设计 A_Memorix 的取消/持久化协议。
+
+合作式超时不能强制中断阻塞 I/O 或拒绝取消的协程。Runner 收到外部停止请求后有独立
+60 秒截止，必要时强杀 Worker 并返回失败；Compose 为此保留 70 秒宽限期。直接运行
+Worker、无外部停止请求的内部关闭，以及 Windows 无控制台 CTRL_BREAK 投递，都不能
+无条件套用这一进程级保证。
+
+成功的 restart 请求保留退出码 42；清理失败返回非零，不把“进程已退出”当作持久化成功。
+Runner 的循环停止判定与 `Popen()` 不是原子操作：判定后才到达的信号可能让一个 Worker
+短暂启动，随后立即被通知关闭；本修复不承诺停止与进程创建之间的零窗口屏障。
+Worker 生命周期中统一拥有信号并临时替换 Uvicorn capture_signals，退出时恢复；升级
+Uvicorn 后应重新验证这一兼容点。

--- a/pytests/startup_test/memory_shutdown_fixture.py
+++ b/pytests/startup_test/memory_shutdown_fixture.py
@@ -1,0 +1,71 @@
+"""阻断存储测试不需要的宿主导入；A_Memorix 内核/生命周期/存储全部保持真实。"""
+
+from contextlib import contextmanager
+from types import ModuleType
+
+import logging
+import socket
+import sys
+import threading
+
+
+def forbidden(*args, **kwargs):
+    raise AssertionError("Host configuration, messaging and network are forbidden in storage tests")
+
+
+class UnusedHost:
+    def __getattr__(self, name):
+        return forbidden(name)
+
+
+def install(monkeypatch) -> None:
+    modules = {
+        "src.chat": {"__path__": []},
+        "src.chat.message_receive": {"__path__": []},
+        "src.chat.message_receive.chat_manager": {"chat_manager": UnusedHost()},
+        "src.services.llm_service": {"LLMServiceClient": UnusedHost},
+        "src.services.message_service": {
+            "get_messages_by_time_in_chat": forbidden,
+            "build_readable_messages": forbidden,
+        },
+        "src.llm_models.model_client": {"__path__": []},
+        "src.llm_models.model_client.base_client": {"EmbeddingRequest": UnusedHost, "client_registry": UnusedHost()},
+        "src.common.data_models.llm_service_data_models": {"LLMServiceResult": UnusedHost},
+        "src.common.database.database": {"get_db_session": forbidden, "SHUTDOWN_TEST_STUB": True},
+        "src.common.database.database_model": {"PersonInfo": UnusedHost},
+        "src.config.config": {"config_manager": UnusedHost(), "global_config": UnusedHost()},
+        "src.common.logger": {"get_logger": logging.getLogger},
+    }
+    for name, exports in modules.items():
+        module = ModuleType(name)
+        module.__dict__.update(exports)
+        monkeypatch.setitem(sys.modules, name, module)
+    original_connect, original_pair = socket.socket.connect, socket.socketpair
+    internal = threading.local()
+
+    def connect(sock, address):
+        if getattr(internal, "socketpair", False):
+            return original_connect(sock, address)
+        return forbidden()
+
+    def socketpair(*args, **kwargs):
+        # Windows asyncio 自唤醒管道使用 stdlib 的 loopback socketpair，不是业务网络。
+        internal.socketpair = True
+        try:
+            return original_pair(*args, **kwargs)
+        finally:
+            internal.socketpair = False
+
+    monkeypatch.setattr(socket.socket, "connect", connect)
+    monkeypatch.setattr(socket, "socketpair", socketpair)
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    monkeypatch.setattr(socket, "getaddrinfo", forbidden)
+
+
+@contextmanager
+def isolated():
+    from pytest import MonkeyPatch
+
+    with MonkeyPatch.context() as patch:
+        install(patch)
+        yield patch

--- a/pytests/startup_test/shutdown_fixture.py
+++ b/pytests/startup_test/shutdown_fixture.py
@@ -1,0 +1,224 @@
+"""隔离加载真实 bot 生命周期函数，不导入配置、模型、数据库或网络客户端。"""
+
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import TypeVar
+
+import ast
+import asyncio
+import os
+import signal
+import sys
+import traceback
+import time
+
+from src.common.shutdown import application_signal_handlers
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_bot_functions(events, *, memory_failure=False, memory_delay=0, install_module=None):
+    class Logger:
+        def info(self, text, **kwargs):
+            events.append(str(text))
+
+        warning = info
+        error = info
+        debug = info
+        exception = info
+
+    def record(name):
+        async def run(*args, **kwargs):
+            events.append(name)
+
+        return run
+
+    async def stop_memory():
+        events.append("memory_stop")
+        await asyncio.sleep(memory_delay)
+        if memory_failure:
+            raise RuntimeError("fixture persist failed")
+        events.extend(["persist", "metadata_close", "writer_lock_release"])
+
+    modules = {
+        "src.config.config": {"config_manager": SimpleNamespace(stop_file_watcher=record("watcher_stop"))},
+        "src.core.event_bus": {"event_bus": SimpleNamespace(emit=record("on_stop"))},
+        "src.core.types": {"EventType": SimpleNamespace(ON_STOP="on_stop")},
+        "src.plugin_runtime.integration": {
+            "get_plugin_runtime_manager": lambda: SimpleNamespace(stop=record("plugin_stop"))
+        },
+        "src.A_memorix.host_service": {"a_memorix_host_service": SimpleNamespace(stop=stop_memory)},
+        "src.services.memory_flow_service": {
+            "memory_automation_service": SimpleNamespace(shutdown=record("memory_producer_stop"))
+        },
+        "src.emoji_system.emoji_manager": {
+            "emoji_manager": SimpleNamespace(shutdown=lambda: events.append("emoji_stop"))
+        },
+        "src.mcp_module.service": {"get_mcp_service": lambda: SimpleNamespace(close=record("mcp_close"))},
+    }
+    for name, values in modules.items():
+        module = ModuleType(name)
+        module.__dict__.update(values)
+        if install_module is None:
+            sys.modules[name] = module
+        else:
+            install_module(name, module)
+
+    namespace = {
+        "asyncio": asyncio,
+        "sys": sys,
+        "signal": signal,
+        "traceback": traceback,
+        "Path": Path,
+        "time": time,
+        "MainSystem": SimpleNamespace,
+        "_RunResultT": TypeVar("T"),
+        "logger": Logger(),
+        "t": lambda key, **kw: key,
+        "tn": lambda key, count: key,
+        "request_shutdown": lambda reason: events.append("request_shutdown"),
+        "async_task_manager": SimpleNamespace(stop_and_wait_all_tasks=record("manager_stop")),
+        "_active_main_loop": None,
+        "_active_main_task": None,
+        "_shutdown_signal_count": 0,
+        "_shutdown_task": None,
+        "_shutdown_deadline": None,
+        "SHUTDOWN_TIMEOUT": 50.0,
+    }
+    tree = ast.parse((ROOT / "bot.py").read_text(encoding="utf-8"))
+    functions = [node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    exec(compile(ast.Module(body=functions, type_ignores=[]), str(ROOT / "bot.py"), "exec"), namespace)
+    system = SimpleNamespace(
+        webui_server=SimpleNamespace(shutdown=record("webui_stop")), app=SimpleNamespace(stop=record("app_stop"))
+    )
+    return namespace, system, tree
+
+
+def run_fixture_worker(fail=False, self_stop=False, restart=False, early_stop=False, shutdown_at=None, repeated=False):
+    """供 POSIX 子进程测试使用；执行真实 Worker __main__，业务服务均为 fake。"""
+
+    class Events(list):
+        def append(self, value):
+            super().append(value)
+            print(value, flush=True)
+
+        def extend(self, values):
+            for value in values:
+                self.append(value)
+
+    events = Events()
+    ns, system, tree = load_bot_functions(events, memory_failure=fail, memory_delay=0.2)
+
+    def stop():
+        signal.raise_signal(signal.SIGTERM)
+        if repeated:
+            signal.raise_signal(signal.SIGINT)
+            signal.raise_signal(signal.SIGTERM)
+
+    if shutdown_at in {"before_publish", "after_publish"}:
+        publish = ns["_set_active_main_task"]
+
+        def publish_at_boundary(task):
+            if task.get_coro().__name__ == "schedule" and shutdown_at == "before_publish":
+                stop()
+            publish(task)
+            if task.get_coro().__name__ == "schedule" and shutdown_at == "after_publish":
+                stop()
+
+        ns["_set_active_main_task"] = publish_at_boundary
+    if shutdown_at == "after_init":
+        drive = ns["_run_until_complete"]
+
+        def drive_at_boundary(loop, task):
+            result = drive(loop, task)
+            if task.get_coro().__name__ == "initialize":
+                stop()
+            return result
+
+        ns["_run_until_complete"] = drive_at_boundary
+    if early_stop:
+        ns["_install_early_worker_signal_handlers"]()
+        print("worker_booting", flush=True)
+        if self_stop:
+            signal.raise_signal(signal.SIGTERM)
+        time.sleep(0.5)
+
+    async def initialize():
+        events.append("initialize")
+        if shutdown_at == "init_pending":
+            stop()
+            await asyncio.Event().wait()
+        if shutdown_at == "init_return":
+            # 精确 P1：取消回调看到 initialize 已 done 后返回，停止标记必须留给下一任务。
+            stop()
+
+    async def schedule():
+        from uvicorn import Config, Server
+
+        if shutdown_at:
+            events.append("schedule_entered")
+            if shutdown_at not in {"after_publish", "scheduled"}:
+                raise SystemExit(9)  # fail fast：不允许丢失停止请求后挂住测试子进程。
+        if restart:
+            raise SystemExit(42)
+
+        class TestServer(Server):
+            async def _serve(self, sockets=None):
+                print("worker_ready", flush=True)
+                if self_stop:
+                    asyncio.get_running_loop().call_soon(signal.raise_signal, signal.SIGTERM)
+                if shutdown_at == "scheduled":
+                    stop()
+                await asyncio.Event().wait()
+
+        try:
+            await TestServer(Config(app=None, log_config=None)).serve()
+        except asyncio.CancelledError:
+            events.append("schedule_cancelled")
+            raise
+
+    system.initialize = initialize
+    system.schedule_tasks = schedule
+    module = ModuleType("src.common.logger")
+    module.initialize_ws_handler = lambda loop: None
+    sys.modules[module.__name__] = module
+    ns.update(
+        {
+            "__name__": "__main__",
+            "raw_main": lambda: system,
+            "os": os,
+            "loop": None,
+            "set_main_loop": lambda loop: None,
+            "shutdown_logging": lambda: None,
+            "application_signal_handlers": application_signal_handlers,
+            "RESTART_EXIT_CODE": 42,
+        }
+    )
+    # 最后一个 __main__ 是 Worker 入口；不运行 bot 顶层的真实依赖初始化。
+    exec(compile(ast.Module(body=[tree.body[-1]], type_ignores=[]), "bot.py", "exec"), ns)
+
+
+if __name__ == "__main__":
+    if "--worker" in sys.argv:
+        run_fixture_worker(
+            "--fail" in sys.argv,
+            "--self-stop" in sys.argv,
+            "--restart" in sys.argv,
+            "--early-stop" in sys.argv,
+            next((arg.split("=", 1)[1] for arg in sys.argv if arg.startswith("--shutdown-at=")), None),
+            "--repeated" in sys.argv,
+        )
+    else:
+        from src.common.process_runner import supervise_worker
+        import logging
+
+        logging.basicConfig(level=logging.INFO)
+        code = supervise_worker(
+            [sys.executable, "-m", "pytests.startup_test.shutdown_fixture", "--worker"]
+            + (["--fail"] if "--fail" in sys.argv else [])
+            + (["--early-stop"] if "--early-stop" in sys.argv else []),
+            os.environ.copy(),
+            logging.getLogger("fixture"),
+        )
+        print("runner_exit=" + str(code), flush=True)
+        raise SystemExit(code)

--- a/pytests/startup_test/test_graceful_shutdown.py
+++ b/pytests/startup_test/test_graceful_shutdown.py
@@ -1,0 +1,467 @@
+"""不启动真实 Bot；覆盖信号、关闭次序、失败状态以及 Runner 的重启协议。"""
+
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+import ast
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+
+import pytest
+from uvicorn import Config, Server
+
+from pytests.startup_test.shutdown_fixture import ROOT, load_bot_functions
+from src.common import process_runner
+from src.common.shutdown import application_signal_handlers
+
+
+@pytest.fixture
+def bot(monkeypatch):
+    events = []
+
+    def make(**kwargs):
+        ns, system, _ = load_bot_functions(
+            events, install_module=lambda k, v: monkeypatch.setitem(sys.modules, k, v), **kwargs
+        )
+        return ns, system, events
+
+    return make
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_shutdown_once_and_memory_before_remaining_cancellation(bot, fail):
+    ns, system, events = bot(memory_failure=fail)
+    loop = asyncio.new_event_loop()
+
+    async def remaining():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            events.append("remaining_cancelled")
+
+    try:
+        loop.create_task(remaining())
+        loop.run_until_complete(asyncio.sleep(0))
+        assert ns["_run_graceful_shutdown"](loop, system) is (not fail)
+        assert ns["_run_graceful_shutdown"](loop, system) is (not fail)
+        assert events.count("memory_stop") == 1
+        assert events.index("memory_producer_stop") < events.index("memory_stop") < events.index("remaining_cancelled")
+        assert ("startup.shutdown_completed" in events) is (not fail)
+        if not fail:
+            assert events.index("persist") < events.index("metadata_close") < events.index("writer_lock_release")
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize(
+    "signals",
+    [
+        (signal.SIGTERM,),
+        (signal.SIGTERM, signal.SIGTERM),
+        (signal.SIGINT, signal.SIGTERM),
+        (signal.SIGTERM, signal.SIGINT),
+    ],
+)
+def test_worker_signals_survive_uvicorn_and_cancel_only_once(bot, signals):
+    ns, system, events = bot()
+    loop = asyncio.new_event_loop()
+    ns["_active_main_loop"] = loop
+    original_capture = Server.capture_signals
+    original_term = signal.getsignal(signal.SIGTERM)
+
+    class TestServer(Server):
+        async def _serve(self, sockets=None):
+            for sig in signals:
+                signal.raise_signal(sig)
+            await asyncio.Event().wait()
+
+    try:
+        with application_signal_handlers(ns["_mark_shutdown_and_interrupt"]):
+            server = TestServer(Config(app=None, log_config=None))
+            task = loop.create_task(server.serve())
+            ns["_active_main_task"] = task
+            with pytest.raises(asyncio.CancelledError):
+                loop.run_until_complete(task)
+            assert task.cancelling() == 1
+            assert ns["_run_graceful_shutdown"](loop, system)
+            signal.raise_signal(signal.SIGTERM)
+            assert ns["_run_graceful_shutdown"](loop, system)
+            assert events.count("memory_stop") == 1
+        assert Server.capture_signals is original_capture
+        assert signal.getsignal(signal.SIGTERM) is original_term
+    finally:
+        loop.close()
+
+
+def test_repeated_signal_during_memory_shutdown_does_not_cancel_it(bot):
+    ns, system, events = bot(memory_delay=0.02)
+    loop = asyncio.new_event_loop()
+    ns["_active_main_loop"] = loop
+    try:
+        with application_signal_handlers(ns["_mark_shutdown_and_interrupt"]):
+            loop.call_later(0.01, signal.raise_signal, signal.SIGTERM)
+            assert ns["_run_graceful_shutdown"](loop, system)
+        assert events.count("memory_stop") == 1
+        assert "metadata_close" in events
+    finally:
+        loop.close()
+
+
+def test_shutdown_step_timeout_and_cancelled_shutdown_are_failures(bot):
+    ns, system, events = bot()
+    loop = asyncio.new_event_loop()
+    try:
+        assert not loop.run_until_complete(
+            ns["_await_shutdown_step"](asyncio.sleep(1), timeout=0.001, step_name="test")
+        )
+        cancelled = loop.create_task(asyncio.sleep(1))
+        cancelled.cancel()
+        ns["_shutdown_task"] = cancelled
+        assert not ns["_run_graceful_shutdown"](loop, system)
+        assert "startup.shutdown_completed" not in events
+    finally:
+        loop.close()
+
+
+def test_shutdown_steps_share_one_deadline(bot, monkeypatch):
+    ns, system, events = bot()
+    clock = [0.0]
+    ns["time"] = SimpleNamespace(monotonic=lambda: clock[0])
+    ns["_shutdown_deadline"] = 50.0
+    timeouts = []
+
+    async def timeout_step(awaitable, timeout):
+        await awaitable
+        timeouts.append(timeout)
+        clock[0] += timeout
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", timeout_step)
+
+    async def run():
+        for _ in range(3):
+            assert not await ns["_await_shutdown_step"](asyncio.sleep(0), timeout=30, step_name="fixture")
+
+    asyncio.run(run())
+    assert timeouts == [30.0, 20.0, 0.0]
+    assert clock[0] == 50
+
+
+def test_emoji_failure_does_not_skip_later_cleanup(bot):
+    ns, system, events = bot()
+
+    def fail():
+        raise RuntimeError("fixture emoji cleanup")
+
+    sys.modules["src.emoji_system.emoji_manager"].emoji_manager.shutdown = fail
+    loop = asyncio.new_event_loop()
+    try:
+        assert not ns["_run_graceful_shutdown"](loop, system)
+        assert "mcp_close" in events
+        assert "manager_stop" in events
+        assert "startup.shutdown_completed" not in events
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    handlers = {}
+    clock = [0.0]
+    monkeypatch.setattr(process_runner.signal, "signal", lambda sig, handler: handlers.setdefault(sig, handler))
+    monkeypatch.setattr(process_runner.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(process_runner.time, "sleep", lambda delay: clock.__setitem__(0, clock[0] + delay))
+    monkeypatch.setattr(process_runner, "WORKER_SHUTDOWN_TIMEOUT", 0.3)
+    logger = Mock()
+    return handlers, clock, logger
+
+
+@pytest.mark.parametrize(
+    "stop_signals",
+    [
+        (signal.SIGTERM,),
+        (signal.SIGTERM, signal.SIGTERM),
+        (signal.SIGINT, signal.SIGTERM),
+        (signal.SIGTERM, signal.SIGINT),
+    ],
+)
+@pytest.mark.parametrize("platform_name", ["nt", "posix"])
+def test_runner_forwards_once_and_waits(runner, monkeypatch, stop_signals, platform_name):
+    handlers, clock, logger = runner
+    sent = []
+    monkeypatch.setattr(process_runner, "os", SimpleNamespace(name=platform_name))
+    # 在 POSIX 上也能静态验证 Windows 分支，而不依赖该平台具有控制台常量。
+    monkeypatch.setattr(signal, "SIGBREAK", 21, raising=False)
+    monkeypatch.setattr(signal, "CTRL_BREAK_EVENT", 1, raising=False)
+    monkeypatch.setattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200, raising=False)
+
+    class Worker:
+        returncode = None
+        waits = 0
+
+        def poll(self):
+            return self.returncode
+
+        def send_signal(self, sig):
+            sent.append(sig)
+
+        def wait(self, timeout):
+            self.waits += 1
+            clock[0] += 0.05
+            if self.waits == 1:
+                for sig in stop_signals:
+                    handlers[sig](sig, None)
+            if self.waits == 4:
+                self.returncode = 0
+                return 0
+            raise subprocess.TimeoutExpired("fixture", timeout)
+
+    worker = Worker()
+    monkeypatch.setattr(process_runner.subprocess, "Popen", lambda *a, **kw: worker)
+    assert process_runner.supervise_worker(["fixture"], {}, logger) == 0
+    assert worker.waits == 4
+    assert sent == [signal.CTRL_BREAK_EVENT if platform_name == "nt" else signal.SIGTERM]
+
+
+def test_stop_racing_restart_suppresses_new_worker(runner, monkeypatch):
+    handlers, clock, logger = runner
+    finished = Mock(returncode=42)
+
+    def poll():
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+        return 42
+
+    finished.poll.side_effect = poll
+    popen = Mock(return_value=finished)
+    monkeypatch.setattr(process_runner.subprocess, "Popen", popen)
+    assert process_runner.supervise_worker(["fixture"], {}, logger) == 42
+    popen.assert_called_once()
+    finished.send_signal.assert_not_called()
+
+
+def test_runner_timeout_kills_and_returns_failure(runner, monkeypatch):
+    handlers, clock, logger = runner
+    worker = Mock(returncode=None)
+    worker.poll.side_effect = lambda: worker.returncode
+
+    def wait(timeout):
+        if worker.returncode is not None:
+            return worker.returncode
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+        clock[0] += 0.1
+        raise subprocess.TimeoutExpired("fixture", timeout)
+
+    worker.wait.side_effect = wait
+    worker.kill.side_effect = lambda: setattr(worker, "returncode", 1)
+    monkeypatch.setattr(process_runner.subprocess, "Popen", lambda *a, **kw: worker)
+    assert process_runner.supervise_worker(["fixture"], {}, logger) == 1
+    worker.send_signal.assert_called_once()
+    worker.kill.assert_called_once()
+    assert clock[0] >= 0.3
+    logger.error.assert_called_once()
+
+
+def test_runner_restart_42_and_exited_worker_signal(runner, monkeypatch):
+    handlers, clock, logger = runner
+    workers = [Mock(returncode=42), Mock(returncode=0)]
+    for worker in workers:
+        worker.poll.side_effect = lambda w=worker: w.returncode
+    popen = Mock(side_effect=workers)
+    monkeypatch.setattr(process_runner.subprocess, "Popen", popen)
+    assert process_runner.supervise_worker(["fixture"], {}, logger) == 0
+    assert popen.call_count == 2
+    assert clock[0] >= 1
+
+    finished = Mock(returncode=0)
+
+    def poll():
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+        return 0
+
+    finished.poll.side_effect = poll
+    popen.side_effect = [finished]
+    assert process_runner.supervise_worker(["fixture"], {}, logger) == 0
+    finished.send_signal.assert_not_called()
+
+
+@pytest.mark.parametrize("fail,restart,code", [(False, False, 0), (True, False, 1), (False, True, 42), (True, True, 1)])
+def test_real_worker_entrypoint_exit_semantics(fail, restart, code):
+    args = [sys.executable, "-u", "-m", "pytests.startup_test.shutdown_fixture", "--worker", "--self-stop"]
+    args += ["--fail"] if fail else []
+    args += ["--restart"] if restart else []
+    result = subprocess.run(
+        args,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=os.environ | {"PYTHONUTF8": "1"},
+        timeout=10,
+    )
+    assert result.returncode == code, result.stdout + result.stderr
+    assert result.stdout.splitlines().count("memory_stop") == 1
+    assert ("startup.shutdown_completed" in result.stdout) is (not fail)
+    assert ("metadata_close" in result.stdout) is (not fail)
+
+
+def test_real_worker_consumes_stop_received_during_startup():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-u",
+            "-m",
+            "pytests.startup_test.shutdown_fixture",
+            "--worker",
+            "--self-stop",
+            "--early-stop",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=os.environ | {"PYTHONUTF8": "1"},
+        timeout=10,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "worker_booting" in result.stdout
+    assert "initialize" not in result.stdout
+    assert result.stdout.splitlines().count("memory_stop") == 1
+    assert "startup.shutdown_completed" in result.stdout
+
+
+def test_early_worker_guard_runs_before_business_imports(bot, monkeypatch):
+    ns, system, events = bot()
+    tree = ast.parse((ROOT / "bot.py").read_text(encoding="utf-8"))
+    business_import = next(
+        i for i, node in enumerate(tree.body) if isinstance(node, ast.ImportFrom) and node.module.startswith("src.")
+    )
+    guard = next(
+        node
+        for node in tree.body[:business_import]
+        if isinstance(node, ast.If) and "_install_early_worker_signal_handlers" in ast.unparse(node)
+    )
+    installed = {}
+    monkeypatch.setattr(signal, "signal", lambda sig, handler: installed.setdefault(sig, handler))
+    ns.update(__name__="__main__", os=SimpleNamespace(environ={"MAIBOT_WORKER_PROCESS": "1"}))
+    exec(compile(ast.Module(body=[guard], type_ignores=[]), "bot.py", "exec"), ns)
+    assert installed[signal.SIGTERM] is ns["_mark_shutdown_and_interrupt"]
+    installed[signal.SIGTERM](signal.SIGTERM, None)
+    assert ns["_shutdown_signal_count"] == 1
+    assert not events  # Business services are not accessed before the loop is ready.
+
+
+@pytest.mark.skipif(os.name != "posix", reason="需要真实 POSIX 信号；Windows terminate() 不是 SIGTERM")
+@pytest.mark.parametrize("fail", [False, True])
+@pytest.mark.parametrize("early", [False, True])
+def test_posix_real_runner_worker_shutdown(fail, early):
+    args = [sys.executable, "-u", "-m", "pytests.startup_test.shutdown_fixture"] + (["--fail"] if fail else [])
+    args += ["--early-stop"] if early else []
+    process = subprocess.Popen(args, cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    import queue
+    import threading
+
+    lines = queue.Queue()
+    reader = threading.Thread(target=lambda: [lines.put(line) for line in process.stdout], daemon=True)
+    reader.start()
+    output = []
+    try:
+        while True:
+            line = lines.get(timeout=10)
+            output.append(line)
+            if ("worker_booting" if early else "worker_ready") in line:
+                break
+        process.send_signal(signal.SIGTERM)
+        assert process.wait(timeout=10) == (1 if fail else 0)
+        reader.join(timeout=1)
+        while not lines.empty():
+            output.append(lines.get_nowait())
+        text = "".join(output)
+        assert text.splitlines().count("memory_stop") == 1
+        assert ("startup.shutdown_completed" in text) is (not fail)
+        assert "runner_exit=" + str(1 if fail else 0) in text
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+
+@pytest.mark.parametrize(
+    "shutdown_at", ["init_pending", "init_return", "after_init", "before_publish", "after_publish", "scheduled"]
+)
+@pytest.mark.parametrize("repeated", [False, True])
+def test_worker_consumes_shutdown_across_task_handoff(shutdown_at, repeated):
+    args = [
+        sys.executable,
+        "-u",
+        "-m",
+        "pytests.startup_test.shutdown_fixture",
+        "--worker",
+        f"--shutdown-at={shutdown_at}",
+    ]
+    if repeated:
+        args.append("--repeated")
+    result = subprocess.run(
+        args,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=10,
+        env=os.environ | {"PYTHONUTF8": "1", "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = result.stdout.splitlines()
+    scheduler_started = shutdown_at in {"after_publish", "scheduled"}
+    assert ("schedule_entered" in lines) is scheduler_started
+    assert ("schedule_cancelled" in lines) is scheduler_started
+    if scheduler_started:
+        assert lines.index("schedule_cancelled") < lines.index("startup.shutdown_started")
+    assert lines.count("startup.shutdown_started") == lines.count("memory_stop") == 1
+    assert lines.count("startup.shutdown_completed") == 1
+    assert lines.index("memory_stop") < lines.index("metadata_close") < lines.index("startup.shutdown_completed")
+
+
+@pytest.mark.parametrize("point", ["before_publish", "after_publish", "after_check"])
+def test_signal_on_publication_boundaries_cancels_once(bot, point):
+    ns, system, events = bot()
+    loop = asyncio.new_event_loop()
+    ns["_active_main_loop"] = loop
+    publish = ns["_set_active_main_task"]
+    triggered = False
+
+    def stop():
+        nonlocal triggered
+        triggered = True
+        ns["_mark_shutdown_and_interrupt"](signal.SIGTERM, None)
+
+    def trace(frame, event, arg):
+        # 精确在赋值后/条件求值后注入；执行原函数，不复制其发布逻辑。
+        if frame.f_code is publish.__code__ and not triggered:
+            if point == "after_publish" and event == "line" and ns["_active_main_task"] is task:
+                stop()
+            elif point == "after_check" and event == "return":
+                stop()
+        return trace
+
+    async def scheduler():
+        await asyncio.Event().wait()
+
+    previous_trace = sys.gettrace()
+    task = loop.create_task(scheduler())
+    try:
+        if point == "before_publish":
+            stop()
+        sys.settrace(trace)
+        publish(task)
+        sys.settrace(previous_trace)
+        with pytest.raises(asyncio.CancelledError):
+            ns["_run_until_complete"](loop, task)
+        assert triggered and task.cancelling() == 1
+        assert ns["_run_graceful_shutdown"](loop, system)
+        assert events.count("memory_stop") == 1
+    finally:
+        sys.settrace(previous_trace)
+        loop.close()

--- a/pytests/startup_test/test_graceful_shutdown.py
+++ b/pytests/startup_test/test_graceful_shutdown.py
@@ -264,6 +264,25 @@ def test_runner_timeout_kills_and_returns_failure(runner, monkeypatch):
     logger.error.assert_called_once()
 
 
+def test_runner_kill_reap_timeout_returns_failure(runner, monkeypatch):
+    handlers, clock, logger = runner
+    worker = Mock(returncode=None)
+    worker.poll.return_value = None
+
+    def wait(timeout):
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+        clock[0] += 0.1
+        raise subprocess.TimeoutExpired("fixture", timeout)
+
+    worker.wait.side_effect = wait
+    monkeypatch.setattr(process_runner.subprocess, "Popen", lambda *a, **kw: worker)
+
+    assert process_runner.supervise_worker(["fixture"], {}, logger) == 1
+    worker.kill.assert_called_once()
+    assert worker.wait.call_args_list[-1].kwargs == {"timeout": 5}
+    logger.error.assert_any_call("Worker 强制终止后仍无法回收；应用关闭未完成")
+
+
 def test_runner_restart_42_and_exited_worker_signal(runner, monkeypatch):
     handlers, clock, logger = runner
     workers = [Mock(returncode=42), Mock(returncode=0)]

--- a/src/common/process_runner.py
+++ b/src/common/process_runner.py
@@ -46,7 +46,10 @@ def supervise_worker(command: Sequence[str], env: dict[str, str], logger) -> int
                 if deadline is not None and time.monotonic() >= deadline:
                     logger.error("Worker 优雅关闭超时，强制终止；应用关闭未完成")
                     process.kill()
-                    process.wait(timeout=5)
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        logger.error("Worker 强制终止后仍无法回收；应用关闭未完成")
                     return 1
                 try:
                     process.wait(timeout=0.1)

--- a/src/common/process_runner.py
+++ b/src/common/process_runner.py
@@ -1,0 +1,66 @@
+"""Runner 的信号转发与有界退出；不加载 Worker 的业务依赖。"""
+
+from collections.abc import Sequence
+
+import os
+import signal
+import subprocess
+import time
+
+RESTART_EXIT_CODE = 42
+WORKER_SHUTDOWN_TIMEOUT = 60.0
+
+
+def supervise_worker(command: Sequence[str], env: dict[str, str], logger) -> int:
+    """保留退出码 42 的重启语义；停止请求优先于尚未执行的重启。"""
+    stop_requested = False
+
+    def request_stop(_signum, _frame):
+        nonlocal stop_requested
+        # handler 只记状态，不等待、不重复向正在清理的 Worker 发信号。
+        stop_requested = True
+
+    signals = [signal.SIGINT, signal.SIGTERM]
+    if os.name == "nt":
+        signals.append(signal.SIGBREAK)
+    previous = {sig: signal.signal(sig, request_stop) for sig in signals}
+    try:
+        while not stop_requested:
+            kwargs = {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP} if os.name == "nt" else {}
+            process = subprocess.Popen(command, env=env, **kwargs)
+            deadline = None
+            while process.poll() is None:
+                if stop_requested and deadline is None:
+                    deadline = time.monotonic() + WORKER_SHUTDOWN_TIMEOUT
+                    logger.info("Runner 请求 Worker 优雅关闭，等待完成（最多 60 秒）")
+                    try:
+                        # Windows 的 terminate() 是强制结束，不是 SIGTERM。
+                        # 独立控制台进程组通过 CTRL_BREAK 进入 Worker 的关闭 handler。
+                        process.send_signal(signal.CTRL_BREAK_EVENT if os.name == "nt" else signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass  # Worker 已在 poll 与 send_signal 之间退出。
+                    except OSError:
+                        logger.error("Runner 无法发送受控停止信号；应用关闭未确认完成")
+                        # 仍保留等待窗口；不可把发送失败当成已优雅退出。
+                        # 若 Worker 自行结束则保留其退出码，否则到期后强制结束。
+                if deadline is not None and time.monotonic() >= deadline:
+                    logger.error("Worker 优雅关闭超时，强制终止；应用关闭未完成")
+                    process.kill()
+                    process.wait(timeout=5)
+                    return 1
+                try:
+                    process.wait(timeout=0.1)
+                except subprocess.TimeoutExpired:
+                    pass
+            code = process.returncode
+            if stop_requested or code != RESTART_EXIT_CODE:
+                # 在停止与 restart=42 竞态中不再拉起新 Worker，也不伪装成功。
+                return code if code >= 0 else 128 - code
+            logger.info("Worker 请求重启（退出码 42）")
+            restart_at = time.monotonic() + 1.0
+            while not stop_requested and time.monotonic() < restart_at:
+                time.sleep(0.05)
+        return 0
+    finally:
+        for sig, handler in previous.items():
+            signal.signal(sig, handler)

--- a/src/common/shutdown.py
+++ b/src/common/shutdown.py
@@ -2,6 +2,9 @@
 
 from threading import Event
 
+import contextlib
+import signal
+
 _shutdown_requested = Event()
 
 
@@ -16,3 +19,32 @@ def is_shutdown_requested() -> bool:
     """返回当前进程是否已经进入关停流程。"""
 
     return _shutdown_requested.is_set()
+
+
+@contextlib.contextmanager
+def application_signal_handlers(handler):
+    """Worker 统一拥有停止信号，包括进程内的第三方 Uvicorn 服务。
+
+    Uvicorn 的 capture_signals 会覆盖应用 handler，并在退出时重新发送信号。
+    在 Worker 生命周期内关闭这个捕获层，避免 HTTP 服务关闭代替应用关闭。
+    作用域退出时还原；不影响 Runner、独立服务器或其他进程。
+    """
+    from uvicorn import Server
+
+    signals = [signal.SIGINT, signal.SIGTERM]
+    if hasattr(signal, "SIGBREAK"):
+        signals.append(signal.SIGBREAK)
+    previous = {sig: signal.signal(sig, handler) for sig in signals}
+    capture_signals = Server.capture_signals
+
+    @contextlib.contextmanager
+    def application_owned_signals(_server):
+        yield
+
+    Server.capture_signals = application_owned_signals
+    try:
+        yield
+    finally:
+        Server.capture_signals = capture_signals
+        for sig, original in previous.items():
+            signal.signal(sig, original)


### PR DESCRIPTION
# 请填写以下内容

1. - [x] `main` 分支 **禁止修改**，确认本次提交目标为 `dev`，不是 `main`
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读其修改政策（本 PR 未修改该目录的运行实现）
6. 破坏性更新：**无**。
7. 本次更新的内容和目的：

### 问题

- Docker stop 时，Runner 原先不能可靠等待 Worker 完成应用级 graceful shutdown。
- Worker 实际关闭路径未可靠 await `a_memorix_host_service.stop()`。
- `initialize → scheduler` 任务交接时，初始化 task 已结束可能导致 pending stop request 丢失。

### 修复

- Runner 捕获并转发 SIGTERM，等待 Worker；最多等待 60 秒，超时强制终止并返回 failure。
- Worker 统一进入应用级 shutdown，在剩余 task cancellation 前 await A_Memorix stop；清理失败不记录关闭成功。
- 先登记新 active task，再消费持久停止标记，避免任务交接丢失请求及重复取消。
- 保持 repeated signals 与 restart=42 语义，Compose stop grace period 调整为 70 秒。

### 测试

最终真实 Linux/Docker CI：[Shutdown Linux Isolation #33423491114](https://github.com/ShiinaWhite/MaiBot/actions/runs/33423491114)，全部通过：

| 测试 | 结果 |
| --- | --- |
| P1 task-handoff regressions | 15 passed |
| 真实 POSIX tests | 4 passed |
| graceful shutdown regression | 27 passed |
| Host / real storage | 6 passed |

以上均为零 skipped/failure/error。两种真实拓扑 `Runner PID1` 与 `docker-init → Runner → Worker` 均通过 normal、failure injection、real 60s timeout，使用真实 `docker stop --timeout 70`。

已验证生命周期顺序、Worker 先退出及 Runner 回收、`OOMKilled=false`；timeout 由 Runner 等待约 60 秒后执行，不是 Docker 70 秒 grace 强杀。真实临时存储的 `_persist()`、metadata close、SQLite/vector/graph reopen/readback、writer lock reacquire 均通过。

# 其他信息

- **关联 Issue**：无，本次为 Bug Fix。
- **截图/GIF**：不适用。
- **附加信息**：
  - PR 基于 `2be57599dc3fbad6133f384c2fe2e8d04afad6ef`，仅含 2 个 commits、9 个 runtime/回归测试/文档文件；不包含 evidence-only CI tooling。
  - CI evidence HEAD 为 `5d657561730261683de41e31d7839289046973dc`。其实际被测 runtime/回归文件与本 PR HEAD `48e0db4ca879cc551ccfd396b0b869c2347e8838` 的对应文件逐字节一致，身份及 SHA-256 记录在 artifact 的 `source.json`。
  - 测试仅使用隔离 fixture 和临时合成数据，不连接 QQ、模型 API 或生产服务；不声称生产数据已测试，也不声称未修复 baseline 在同一 CI 中失败。
  - 既有边界已在测试文档说明：Runner stop-check/Popen 非原子窗口、A_Memorix timeout/cancellation 不保证 persist 完成、阻塞 I/O 的 cooperative shutdown 限制，以及 Windows 无控制台 CTRL_BREAK 边界。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化应用启动、停止与重启流程，提升信号处理和资源清理的可靠性。
  * Worker 支持优雅退出、超时强制终止及按需自动重启。
  * 关闭流程采用统一时间预算，并覆盖更多服务与存储步骤。
  * 容器停止时预留更充足的优雅退出时间。

* **Bug 修复**
  * 修复重复信号、启动阶段停止及重启竞争导致的退出异常。
  * 改进关闭失败、取消和超时情况下的状态及退出码处理。

* **测试与文档**
  * 新增启动、关闭、信号、重启和故障传播的回归测试及运行说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->