### PR TITLE
fix(scripts): offline_runner 调用 _build_context_items_from_dict 少传 logical_turn_by_call_id

### DIFF
--- a/scripts/expression_selection/offline_runner.py
+++ b/scripts/expression_selection/offline_runner.py
@@ -264,7 +264,12 @@ async def replay_precise_selector(
 
     def context_factory(_client: object) -> list[Any]:
         del _client
-        return [item for message in raw_messages for item in _build_context_items_from_dict(message)]
+        logical_turn_by_call_id: dict[str, str] = {}
+        return [
+            item
+            for message in raw_messages
+            for item in _build_context_items_from_dict(message, logical_turn_by_call_id)
+        ]
 
     response = await llm_client.generate_response_with_context(
         context_factory,


### PR DESCRIPTION
## 问题

`scripts/expression_selection/offline_runner.py` 里的 `replay_precise_selector` 一定会抛 `TypeError`：

```python
# scripts/expression_selection/offline_runner.py:265
def context_factory(_client: object) -> list[Any]:
    del _client
    return [item for message in raw_messages for item in _build_context_items_from_dict(message)]
```

但被调方要两个参数：

```python
# src/services/llm_service.py:653
def _build_context_items_from_dict(
    raw_message: PromptMessage,
    logical_turn_by_call_id: dict[str, str],
) -> List[ContextItem]:
```

用当前 main 的真实签名重放，并以仓内唯一的另一个调用点作对照组：

```
signature: (raw_message, logical_turn_by_call_id)

  TypeError  offline_runner.py:267  _build_context_items_from_dict(message)
             -> missing a required argument: 'logical_turn_by_call_id'
  OK         llm_service.py:753     _build_context_items_from_dict(raw_message, logical_turn_by_call_id)
```

全仓只有这两个调用点，另一个是对的 —— 看起来是加 `logical_turn_by_call_id` 形参时漏改了这个脚本（同一次改动里 `_build_context_items_from_dict` 的 docstring 也只还写着 `raw_message`）。

## 修复

照抄 `src/services/llm_service.py:747` 的正确写法：

```python
def build_context(_: BaseClient) -> List[ContextItem]:
    logical_turn_by_call_id: dict[str, str] = {}
    return [
        item
        for raw_message in prompt
        for item in _build_context_items_from_dict(raw_message, logical_turn_by_call_id)
    ]
```

所以改成：

```python
def context_factory(_client: object) -> list[Any]:
    del _client
    logical_turn_by_call_id: dict[str, str] = {}
    return [
        item
        for message in raw_messages
        for item in _build_context_items_from_dict(message, logical_turn_by_call_id)
    ]
```

这里有一处刻意保持一致的地方：**这个 dict 在整个 factory 里只建一次，不是每条消息建一次**。它是个累加器 —— assistant 消息在 `llm_service.py:724` 写入 `call_id -> logical_turn_id`，后面的 tool 消息在 `llm_service.py:679` 读回去，用来把工具结果挂到产生它的那次调用上。每条消息各建一个空 dict 虽然也能消掉 `TypeError`，但 `logical_turn_id` 会全部变成 `None`，重放出来的上下文和线上就对不上了。

## 验证

- 上面的签名重放（含对照组），跑在当前 main 的真实源码上。
- 该脚本其余部分是活的，`import` 都能解析：`maisaka_expression_selector`、`expression_vector_index`、`LLMGenerationOptions`、`global_config`、`LLMServiceClient` 均存在，`_build_selector_prompt` 在 `maisaka_expression_selector.py:263`。所以这确实是唯一挡住它的问题。
- 无法端到端跑通：需要 live-log 样本 (`data/analysis/expression_selection_batch_compare_live_intent_*.json`) 和一个真实 LLM 后端，两者都不在仓里。所以这里验证的是 arity 和累加器语义，不是重放结果本身。
- lint 用 `.pre-commit-config.yaml` 里 pin 的 `ruff v0.9.10`，在仓库根目录跑（吃到 `pyproject.toml` 的 `line-length = 120`）：

```console
$ ruff check scripts/expression_selection/offline_runner.py
All checks passed!
$ ruff format --diff scripts/expression_selection/offline_runner.py
1 file already formatted
```

## 顺带发现（本 PR 未动）

`scripts/build_io_pairs.py` 也坏了，但坏得更彻底，不适合塞进这个 PR：

- 第 9 行 `from src.common.data_models.database_data_model import DatabaseMessages` —— 这个模块和 `DatabaseMessages` 全仓已经没有了，脚本在 import 阶段就挂。
- 第 83 行 `find_messages(message_filter=filter_query, ...)` —— `find_messages` 现在是 keyword-only 的显式参数（`session_id`/`platform`/`after_time`/…），没有 `message_filter`；其余约 12 个调用点都已经用新写法。

把它救回来需要替换掉整套数据模型（`chat_id`、`chat_info_platform`、`user_info` 等字段都要重新对应到 `SessionMessage`），已经不是一个 bugfix 的体量了。如果你们希望留着这个脚本，我可以另开一个 PR 做迁移；如果它已经废弃，那删掉可能更合适 —— 告诉我你们倾向哪种，我来跟进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化离线回放过程中上下文信息的构建与关联。
  - 提升多轮交互场景下上下文还原的一致性和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->