### PR TITLE
fix: 操作员权限匹配不再整体转小写 user_id

### DIFF
--- a/src/core/local_operator.py
+++ b/src/core/local_operator.py
@@ -31,13 +31,20 @@ def build_scoped_user_id(platform: str, user_id: str) -> str:
 
 
 def normalize_operator_permissions(permission_list: Iterable[str]) -> Set[str]:
-    """规范化插件管理权限列表。"""
+    """规范化插件管理权限列表。
 
-    return {
-        permission.strip().lower()
-        for permission in permission_list
-        if permission.strip()
-    }
+    与 ``build_scoped_user_id`` 保持一致：仅将平台前缀转小写，``user_id`` 保持原样
+    （openid 等标识符是大小写敏感的，整体转小写会导致匹配失败）。
+    """
+
+    normalized: Set[str] = set()
+    for permission in permission_list:
+        permission = permission.strip()
+        if not permission:
+            continue
+        platform, _, user_id = permission.partition(":")
+        normalized.add(f"{platform.strip().lower()}:{user_id.strip()}")
+    return normalized
 
 
 def has_plugin_management_permission(


### PR DESCRIPTION
# 请填写以下内容

1. - [x] `main` 分支 **禁止修改**，确认本次提交目标为 `dev`，不是 `main`
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读其修改政策（本 PR 未修改该目录的运行实现）
6. 破坏性更新：**无**。
7. 本次更新的内容和目的：

### 问题

- `[plugin].permission` 校验操作员命令（如 `/pm`）时，`normalize_operator_permissions()` 会把整条 `平台:用户ID` 转小写，但 `build_scoped_user_id()` 只转小写平台名、**保留 `user_id` 原样**。
- 当用户标识符大小写敏感（如 QQ 官方 openid `AbCdEf0123456789abcdefABCDEF01` 含大写字母）时：
  - 构造出的 scoped_user_id = `qq:AbCdEf0123456789abcdefABCDEF01`（user_id 原样）
  - 权限项被整体转小写 = `qq:abcdef0123456789abcdefabcdef01`
  - 二者永不相等，导致该用户对所有 `permission="operator"` 命令始终提示「你没有权限使用此命令」。

### 修复

- 让 `normalize_operator_permissions()` 与 `build_scoped_user_id()` 保持一致：**仅转小写平台前缀，`user_id` 保持原样**（大小写敏感匹配，符合 openid 语义）。

```python
def normalize_operator_permissions(permission_list):
    normalized = set()
    for permission in permission_list:
        permission = permission.strip()
        if not permission:
            continue
        platform, _, user_id = permission.partition(":")
        normalized.add(f"{platform.strip().lower()}:{user_id.strip()}")
    return normalized
```

### 测试

`has_plugin_management_permission("qq", "AbCdEf0123456789abcdefABCDEF01", ["qq:AbCdEf0123456789abcdefABCDEF01"], local_operator=False)`：

- 修复前返回 `False`（user_id 大小写不同，永不匹配）
- 修复后返回 `True`（user_id 大小写一致即可匹配）

同时验证：平台大小写不一致（`QQ:`）仍匹配（平台忽略大小写）；user_id 大小写不一致则正确拒绝（保持 openid 大小写敏感语义）。

# 其他信息

- **关联 Issue**：无，本次为 Bug Fix。
- **截图/GIF**：不适用。
- **附加信息**：仅修改 `src/core/local_operator.py` 一处，单 commit。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化权限规范化处理：仅统一平台前缀的大小写，保留用户 ID 的原始大小写。
  * 自动去除用户 ID 首尾空白，并继续忽略空权限条目。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->