### PR TITLE
fix(gemini): 删除 generate_content 中位于 except Exception 之后的不可达重复异常处理块

### DIFF
--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -1140,12 +1140,6 @@ class GeminiClient(AdapterClient[AsyncIterator[GenerateContentResponse], Generat
             if wrapped_error is exc:
                 raise
             raise wrapped_error from exc
-        except (UnknownFunctionCallArgumentError, UnsupportedFunctionError, FunctionInvocationError) as exc:
-            raise RespParseException(None, f"Gemini 工具调用参数错误: {exc}") from exc
-        except EmptyResponseException:
-            raise
-        except Exception as exc:
-            raise NetworkConnectionError(str(exc)) from exc
 
     async def _execute_embedding_request(
         self,


### PR DESCRIPTION
## 问题

`GeminiClient._execute_response_request` 里 `models.generate_content` 的 `try` 块末尾有一组重复的 `except` 处理器，位于 `except Exception as exc:` 这个 catch-all **之后**：

```python
        except Exception as exc:                 # 第 1121 行：捕获一切
            ...
            raise wrapped_error from exc
        except (UnknownFunctionCallArgumentError, UnsupportedFunctionError, FunctionInvocationError) as exc:  # 不可达
            raise RespParseException(None, f"Gemini 工具调用参数错误: {exc}") from exc
        except EmptyResponseException:           # 不可达
            raise
        except Exception as exc:                 # 不可达
            raise NetworkConnectionError(str(exc)) from exc
```

Python 的 `except` 子句按书写顺序自上而下匹配，一次只会命中一个。由于上方的 `except Exception` 已经捕获所有异常，这三个后置处理器**永远不会执行**。

而且这几种异常在上方**已经有更完整的处理器**（第 1094 行处理 `UnknownFunctionCallArgumentError`/`UnsupportedFunctionError`/`FunctionInvocationError`，第 1108 行处理 `EmptyResponseException`），后置的这几行只是不带快照保存逻辑的旧版残留副本。

## 改动

删除这 6 行不可达代码，行为完全不变（它们本就无法被执行到）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误处理**
  - 改进 Gemini 请求失败时的错误信息，网络错误、响应解析失败和空响应现在会附带失败请求快照。
  - 已包含快照的异常将直接保留并重新抛出，避免重复包装。
  - 有助于更准确地定位请求失败原因并提升问题排查效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->